### PR TITLE
Adding a docker build for containerisation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM library/alpine:latest
+
+ENTRYPOINT [ '/usr/bin/argbash' ]
+
+RUN apk add --no-cache \
+	autoconf \
+	make
+
+WORKDIR /usr/share/argbash/
+COPY . .
+RUN cd resources \
+ && make install PREFIX=/usr/lib \
+ && make check
+
+# Make the cli executable and available on the path
+RUN chmod +x /usr/share/argbash/argbash \
+ && ln -s /usr/share/argbash/argbash /usr/bin/
+
+# This is the workspace for exec commands
+WORKDIR /usr/src
+VOLUME  /usr/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,14 @@ RUN apk add --no-cache \
 	autoconf \
 	make
 
-WORKDIR /usr/share/argbash/
-COPY . .
-RUN cd resources \
- && make install PREFIX=/usr/lib \
- && make check
+# Install argbash
+COPY    . /usr/share/argbash/
+WORKDIR /usr/share/argbash/resources/
+RUN     make install PREFIX=/usr/lib
 
 # Make the cli executable and available on the path
-RUN chmod +x /usr/share/argbash/argbash \
- && ln -s /usr/share/argbash/argbash /usr/bin/
+RUN chmod +x /usr/share/argbash/bin/argbash \
+ && ln -s /usr/share/argbash/bin/argbash /usr/bin/
 
 # This is the workspace for exec commands
 WORKDIR /usr/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM library/alpine:latest
 
 # The application requires bash to run.
 RUN apk add --no-cache \
+	autoconf \
 	bash
 
 # Install argbash from sources
 COPY    . /usr/src/argbash/
 WORKDIR /usr/src/argbash/resources/
 RUN     apk add --no-cache --virtual .build-dependencies \
-            autoconf \
             make \
      && make install PREFIX=/usr/local \
      && apk del .build-dependencies
@@ -18,5 +18,5 @@ WORKDIR /work
 VOLUME  /work
 
 # Run argbash with any default invocation.
-ENTRYPOINT [ '/usr/local/bin/argbash' ]
+ENTRYPOINT [ "argbash" ]
 CMD [ "" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,18 @@
 FROM library/alpine:latest
 
-ENTRYPOINT [ '/usr/bin/argbash' ]
+ENTRYPOINT [ '/usr/local/bin/argbash' ]
 
 RUN apk add --no-cache \
-	autoconf \
-	make
+	bash
 
-# Install argbash
-COPY    . /usr/share/argbash/
-WORKDIR /usr/share/argbash/resources/
-RUN     make install PREFIX=/usr/lib
-
-# Make the cli executable and available on the path
-RUN chmod +x /usr/share/argbash/bin/argbash \
- && ln -s /usr/share/argbash/bin/argbash /usr/bin/
+# Install argbash from sources
+COPY    . /usr/src/argbash/
+WORKDIR /usr/src/argbash/resources/
+RUN     apk add --no-cache --virtual .build-dependencies \
+            autoconf \
+            make \
+     && make install PREFIX=/usr/local \
+     && apk del .build-dependencies
 
 # This is the workspace for exec commands
 WORKDIR /usr/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM library/alpine:latest
 
-ENTRYPOINT [ '/usr/local/bin/argbash' ]
-
+# The application requires bash to run.
 RUN apk add --no-cache \
 	bash
 
@@ -15,5 +14,9 @@ RUN     apk add --no-cache --virtual .build-dependencies \
      && apk del .build-dependencies
 
 # This is the workspace for exec commands
-WORKDIR /usr/src
-VOLUME  /usr/src
+WORKDIR /work
+VOLUME  /work
+
+# Run argbash with any default invocation.
+ENTRYPOINT [ '/usr/local/bin/argbash' ]
+CMD [ "" ]


### PR DESCRIPTION
I've already got the app being deployed under `tzrlk/argbash` on dockerhub, and it seems to work fine. Running the command is just a matter of creating an alias or script to execute the following command:

| OS | Command |
| --- | --- |
| **linux** | `docker run -it --rm -v "$(pwd):/work" tzrlk/argbash $*` |
| **windows** | `docker run -it --rm -v "%CD%:/work" tzrlk/argbash %*` |

Of course, if you accept this, you'd have to set up an account on dockerhub to run the automated builds, and the image name would become `matejak/argbash`. The benefit being that the tool will always be up to date, and released versions will be automatically released as specifically tagged images.