### PR TITLE
Fix RPM packaging issues

### DIFF
--- a/resources/Makefile
+++ b/resources/Makefile
@@ -44,7 +44,7 @@ ROOT ?= /
 A_INIT = ../bin/argbash-init
 GENPARSE = ../bin/argbash
 COMPLETION = argbash.sh
-INSTALL_COMPLETION = no
+INSTALL_COMPLETION ?= no
 ARGBASH_EXEC ?= $(GENPARSE)
 ARGBASH_INIT_EXEC ?= $(A_INIT)
 EXAMPLES = \
@@ -152,7 +152,7 @@ install: $(GENPARSE) $(A_INIT) $(ARGBASH_TO) $(COMPLETION)
 	test -n "$(VERSION_SUFFIX)" || test -z "$(ARGBASH_TO)" || { cp -p $(ARGBASH_TO) "$(ROOT)/$(PREFIX)/bin" && chmod a+x "$(ROOT)/$(PREFIX)"/bin/argbash-*; }
 	cp -p $(A_INIT) "$(ROOT)/$(PREFIX)/bin/argbash-init$(VERSION_SUFFIX)" && chmod a+x "$(ROOT)/$(PREFIX)"/bin/argbash-init$(VERSION_SUFFIX)
 	chmod a+x "$(ROOT)/$(PREFIX)/bin/argbash$(VERSION_SUFFIX)"
-	test "$(INSTALL_COMPLETION)" = "no" || mkdir -p "$(ROOT)/$(SYSCONFDIR)/bash_completion.d" && mv "$(COMPLETION)" "$(ROOT)/$(SYSCONFDIR)/bash_completion.d/"
+	test "$(INSTALL_COMPLETION)" = "no" || (mkdir -p "$(ROOT)/$(SYSCONFDIR)/bash_completion.d" && mv "$(COMPLETION)" "$(ROOT)/$(SYSCONFDIR)/bash_completion.d/")
 
 altpreclean: define-version
 	$(RM) "$(ROOT)/$(PREFIX)/bin/argbash-$(VERSION_MAJOR).$(VERSION_MINOR)"

--- a/resources/Makefile
+++ b/resources/Makefile
@@ -152,7 +152,7 @@ install: $(GENPARSE) $(A_INIT) $(ARGBASH_TO) $(COMPLETION)
 	test -n "$(VERSION_SUFFIX)" || test -z "$(ARGBASH_TO)" || { cp -p $(ARGBASH_TO) "$(ROOT)/$(PREFIX)/bin" && chmod a+x "$(ROOT)/$(PREFIX)"/bin/argbash-*; }
 	cp -p $(A_INIT) "$(ROOT)/$(PREFIX)/bin/argbash-init$(VERSION_SUFFIX)" && chmod a+x "$(ROOT)/$(PREFIX)"/bin/argbash-init$(VERSION_SUFFIX)
 	chmod a+x "$(ROOT)/$(PREFIX)/bin/argbash$(VERSION_SUFFIX)"
-	test "$(INSTALL_COMPLETION)" = "no" || mkdir -p "$(SYSCONFDIR)/bash_completion.d" && mv "$(COMPLETION)" "$(SYSCONFDIR)/bash_completion.d/"
+	test "$(INSTALL_COMPLETION)" = "no" || mkdir -p "$(ROOT)/$(SYSCONFDIR)/bash_completion.d" && mv "$(COMPLETION)" "$(ROOT)/$(SYSCONFDIR)/bash_completion.d/"
 
 altpreclean: define-version
 	$(RM) "$(ROOT)/$(PREFIX)/bin/argbash-$(VERSION_MAJOR).$(VERSION_MINOR)"
@@ -170,7 +170,7 @@ uninstall:
 	$(RM) "$(ROOT)/$(PREFIXED_LIBDIR)/argbash$(VERSION_SUFFIX)/version"
 	$(RM) "$(ROOT)/$(PREFIX)"/bin/argbash-*
 	rmdir "$(ROOT)/$(PREFIXED_LIBDIR)/argbash$(VERSION_SUFFIX)"
-	$(RM) "$(SYSCONFDIR)/bash_completion.d/$(COMPLETION)"
+	$(RM) "$(ROOT)/$(SYSCONFDIR)/bash_completion.d/$(COMPLETION)"
 
 altuninstall: define-version uninstall
 

--- a/resources/packages/rpm/argbash.spec.in
+++ b/resources/packages/rpm/argbash.spec.in
@@ -12,22 +12,33 @@ BuildRequires: autoconf
 BuildRequires: coreutils
 BuildRequires: make
 BuildRequires: bash
+BuildRequires: bash-completion
 Requires: autoconf
 Requires: bash
 Requires: coreutils
 Requires: grep
 Requires: sed
 
+%if !0%{?rhel} || 0%{?rhel} > 7
+Recommends: bash-completion
+%endif
+
 %description
 @LONGDESC@
 
 %prep
-%autosetup -n argbash-@VERSION@
+%autosetup
 
 %build
 
 %install
-cd resources && ROOT=%{buildroot} PREFIX=%{_prefix} PREFIXED_LIBDIR=${_datarootdir} make install
+cd resources && \
+    ROOT=%{buildroot} \
+    PREFIX=%{_prefix} \
+    PREFIXED_LIBDIR=%{_datarootdir} \
+    SYSCONFDIR=%{_sysconfdir} \
+    INSTALL_COMPLETION=yes \
+    make install
 
 %check
 cd resources && make check
@@ -39,15 +50,8 @@ cd resources && make check
 %{_bindir}/argbash
 %{_bindir}/argbash-1to2
 %{_bindir}/argbash-init
-
 %{_datarootdir}/argbash/
+%dir %{_sysconfdir}/bash_completion.d/
+%{_sysconfdir}/bash_completion.d/argbash.sh
 
 %changelog
-* Mon Oct 16 2017 Stephen Gallagher <sgallagh@redhat.com> - 2.5.0-1
-- Install libdir in /usr/share since it's platform-independent
-
-* Wed May 24 2017 Stephen Gallagher <sgallagh@redhat.com> - 2.4.0-1
-- Use proper libdir path
-
-* Wed Mar 08 2017 Stephen Gallagher <sgallagh@redhat.com> - 2.3.0-0.1
-- Initial package


### PR DESCRIPTION
RPM packaging was failing because the bash-completion installation had two bugs in it:

1) It did not properly install under `$(ROOT)` which meant that it was trying to install directly in /etc rather than the RPM buildroot.
2) The INSTALL_COMPLETION environment variable had two bugs: first, it was not set `?=`, so it couldn't be overriden at the command-line. Second, the test for it only resulted in the directory not being created; as a result, it was still attempting to copy the `argbash.sh` file into a nonexistent location, which failed.

This patch also updates the RPM packaging.