### PR TITLE
Docopt output fixes and tests.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,8 @@ Bugfixes:
 * Tests pass when there is no dash shell installed.
 * The double-dash handling when `--` is the last argument has been improved.
 * The generated bash completion is now complementing (i.e. not shadowing) the default bash completion.
+* Docopt fatal regression has been fixed.
+* Tests were added for docopt output.
 
 
 2.7.0 (2018-07-19)

--- a/src/output-docopt.m4
+++ b/src/output-docopt.m4
@@ -5,11 +5,15 @@ m4_define([_CAPITALIZE], [m4_translit([[$1]], [a-z], [A-Z])])
 m4_define([_SYNOPSIS_OF_OPTIONAL_ARGS], [m4_lists_foreach_optional([_ARGS_LONG,_ARGS_SHORT,_ARGS_CATH], [_argname,_arg_short,_arg_type], [m4_do(
 	[ @<:@],
 	[m4_case(_arg_type,
-		[bool], [_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_MESSAGE(_argname, )],
-		[arg], [_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_MESSAGE(_argname, , _CAPITALIZE(_argname))],
-		[repeated], [_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_MESSAGE(_argname, , _CAPITALIZE(_argname))...],
-		[_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_MESSAGE(_argname, )])],
+		[bool], [_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_SYNOPSIS(_argname, )],
+		[arg], [_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_SYNOPSIS(_argname, , _CAPITALIZE(_argname))],
+		[repeated], [_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_SYNOPSIS(_argname, , _CAPITALIZE(_argname))],
+		[_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_SYNOPSIS(_argname, )])],
 	[@:>@],
+	[m4_case(_arg_type,
+		[repeated], [...],
+		[incr], [...],
+		[])],
 )])])
 
 
@@ -19,7 +23,7 @@ dnl $2: Padding of $1
 dnl $3: Help (optional)
 dnl $4: Default (optional)
 m4_define([_FORMAT_DOCOPT_OPTION], [m4_do(
-	[m4_format([[  %-$2s]]m4_ifnblank([$3$4], [[[  %s]]])m4_ifnblank([$4], [[[ [default: %s]]]])._ENDL, [$1], [$3], [$4])],
+	[m4_format([[  %-$2s]]m4_ifnblank([$3$4], [[[  %s]]])m4_ifnblank([$4], [[[ [default: %s]]]])._ENDL_(), [$1], [$3], [$4])],
 )])
 
 
@@ -32,13 +36,13 @@ dnl $5: help
 m4_define([_APPEND_TO_LISTS], [m4_do(
 	[m4_list_append([_LIST_LOCAL_HELP], [$5])],
 	[m4_list_append([LIST_DOCOPT_OPTIONALS_SPECS], m4_case(_arg_type,
-		[bool], [_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_MESSAGE([$1], [$2], , [, ])],
-		[action], [_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_MESSAGE([$1], [$2], , [, ])],
-		[_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_MESSAGE([$1], [$2], _CAPITALIZE([$1]), [, ])]))],
+		[bool], [_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_SYNOPSIS([$1], [$2], , [, ])],
+		[action], [_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_SYNOPSIS([$1], [$2], , [, ])],
+		[_FORMAT_OPTIONAL_ARGUMENT_FOR_HELP_SYNOPSIS([$1], [$2], _CAPITALIZE([$1]), [, ])]))],
 	[m4_list_append([_LIST_LOCAL_DEFAULTS], m4_case(_arg_type,
-		[bool], [$4],
+		[bool], [[$4]],
 		[action], [],
-		[$4]))],
+		[[$4]]))],
 )])
 
 
@@ -61,9 +65,6 @@ Options:
 ],
 		[m4_lists_foreach_optional([_ARGS_LONG,_ARGS_SHORT,_ARGS_CATH,_ARGS_DEFAULT,_ARGS_HELP], [_argname,_arg_short,_arg_type,_arg_default,_arg_help],
 			[_APPEND_TO_LISTS(_argname,_arg_short,_arg_type,_arg_default,_arg_help)])],
-		[m4_errprintn(m4_list_len([LIST_DOCOPT_OPTIONALS_SPECS]))],
-		[m4_errprintn(m4_list_len([_LIST_LOCAL_HELP]))],
-		[m4_errprintn(m4_list_len([_LIST_LOCAL_DEFAULTS]))],
 		[m4_lists_foreach([LIST_DOCOPT_OPTIONALS_SPECS,_LIST_LOCAL_HELP,_LIST_LOCAL_DEFAULTS], [spec,_arg_help,_arg_default], [m4_dquote(_FORMAT_DOCOPT_OPTION(spec, _LIST_LONGEST_TEXT_LENGTH([LIST_DOCOPT_OPTIONALS_SPECS]), _arg_help, _arg_default))])],
 		)])
 	)])],

--- a/tests/regressiontests/Makefile
+++ b/tests/regressiontests/Makefile
@@ -17,6 +17,9 @@ ARGBASH_INIT_EXEC ?= $(ARGBASH_INIT)
 
 %.sh: %.m4 $(ARGBASH_BIN)
 	$(word 2,$^) $< -o $@
+
+%.txt: %.m4 $(ARGBASH_BIN)
+	$(word 2,$^) $< -t docopt --strip all -o $@
 TESTS =
 TESTS_GEN =
 
@@ -106,6 +109,12 @@ TESTS += \
 	test-getopt-equals \
 	$(NUL)
 
+# docopt tests
+TESTS += \
+	basic-docopt \
+	test-onlyopt-docopt \
+	$(NUL)
+
 TESTS_GEN += \
 	gen-test-pos \
 	gen-test-opt \
@@ -167,6 +176,8 @@ SCRIPTS += \
 	$(TESTDIR)/test-getopt-both.sh \
 	$(TESTDIR)/test-getopt-space.sh \
 	$(TESTDIR)/test-getopt-equals.sh \
+	$(TESTDIR)/basic.txt \
+	$(TESTDIR)/test-onlyopt.txt \
 	$(NUL)
 
 ifneq "$(shell which dash 2> /dev/null)" ""
@@ -545,6 +556,15 @@ gen-test-badcall-multi: $(TESTDIR)/gen-test-badcall-multi.m4 $(ARGBASH_BIN)
 	ERROR="3rd argument" $(REVERSE) $(ARGBASH_EXEC) $< > /dev/null
 	ERROR="num of args" $(REVERSE) $(ARGBASH_EXEC) $< > /dev/null
 	ERROR="actual number of" $(REVERSE) $(ARGBASH_EXEC) $< > /dev/null
+
+basic-docopt: $(TESTDIR)/basic.txt
+	grep -q "\[<pos-opt>\]" $<
+	grep -q "\[--opt_arg OPT_ARG\]" $<
+	grep -q "\s-o OPT_ARG, --opt_arg OPT_ARG\s" $<
+
+test-onlyopt-docopt: $(TESTDIR)/test-onlyopt.txt
+	grep -q "\[--opt-repeated OPT-REPEATED\]\.\.\." $<
+	grep -q "\[--incrx\]\.\.\." $<
 
 test-delim-space: $(TESTDIR)/test-delim-space.sh
 	ERROR="unexpected argument '--opt=something'" $(REVERSE) $< --opt=something

--- a/tests/regressiontests/make/Makefile.m4
+++ b/tests/regressiontests/make/Makefile.m4
@@ -10,6 +10,7 @@ m4_define([include_test], [m4_do(
 )])
 
 m4_include([tests/tests-base.m4])
+m4_include([tests/tests-docopt.m4])
 m4_include([tests/tests-delimiters.m4])
 m4_include([tests/tests-init.m4])
 m4_include([tests/tests-env.m4])
@@ -37,6 +38,9 @@ ARGBASH_INIT_EXEC ?= $(ARGBASH_INIT)
 
 %.sh: %.m4 $(ARGBASH_BIN)
 	$(word 2,$^) $< -o $@
+
+%.txt: %.m4 $(ARGBASH_BIN)
+	$(word 2,$^) $< -t docopt --strip all -o $@
 m4_divert_pop(STDOUT1)
 
 m4_divert_push(STDOUT2)dnl
@@ -55,6 +59,12 @@ TESTS += \
 	], m4_set_list([BASH_TESTS])) \
 	$(NUL)
 
+# docopt tests
+TESTS += \
+	m4_join([ \
+	], m4_set_list([DOCOPT_TESTS])) \
+	$(NUL)
+
 TESTS_GEN += \
 	m4_join([ \
 	], m4_set_list([_TEST_GEN_BASH])) \
@@ -62,7 +72,7 @@ TESTS_GEN += \
 
 SCRIPTS += \
 	m4_join([ \
-	], m4_set_list([_TEST_BASH_SCRIPTS])) \
+	], m4_set_list([_TEST_BASH_SCRIPTS]),m4_set_list([_TEST_DOCOPT_SCRIPTS])) \
 	$(NUL)
 
 ifneq "$(shell which dash 2> /dev/null)" ""

--- a/tests/regressiontests/make/make.m4
+++ b/tests/regressiontests/make/make.m4
@@ -39,6 +39,29 @@ dnl $3: body
 m4_define([ADD_ARGBASH_RULE], [ADD_RULE(
 	[$1.sh], [$1.m4 $2 $(ARGBASH_BIN)], [$3])])
 
+
+dnl
+dnl $1: The test name
+dnl $2: The test body (see also: TEST_BODY)
+dnl $3: The other deps (literal, feel free to use the | delimiter)
+dnl $4: The first dep (default: $(TESTDIR)/<name>.txt)
+dnl
+dnl Remarks:
+dnl No leading/trailing newlines, around the test body as it already has those.
+m4_define([ADD_DOCOPT_TEST], [m4_do(
+	[m4_pushdef([_script], m4_default_quoted([$4], [$(TESTDIR)/$1.txt]))],
+	[m4_pushdef([_testname], [[$1-docopt]])],
+	[m4_set_add([DOCOPT_TESTS], _testname)],
+	[m4_set_add([_TEST_DOCOPT_SCRIPTS], m4_quote(_script))],
+	[m4_divert_text([STDOUT3], [m4_do(
+		_testname[: _script[]m4_ifnblank([$3], [ $3])],
+		[$2],
+	)])],
+	[m4_popdef([_testname])],
+	[m4_popdef([_script])],
+)])
+
+
 dnl
 dnl $1: The test name
 dnl $2: The test body (see also: TEST_BODY)

--- a/tests/regressiontests/make/tests/tests-docopt.m4
+++ b/tests/regressiontests/make/tests/tests-docopt.m4
@@ -1,0 +1,10 @@
+ADD_DOCOPT_TEST([basic], [[
+	grep -q "\[<pos-opt>\]" $<
+	grep -q "\[--opt_arg OPT_ARG\]" $<
+	grep -q "\s-o OPT_ARG, --opt_arg OPT_ARG\s" $<
+]])
+
+ADD_DOCOPT_TEST([test-onlyopt], [[
+	grep -q "\[--opt-repeated OPT-REPEATED\]\.\.\." $<
+	grep -q "\[--incrx\]\.\.\." $<
+]])


### PR DESCRIPTION
* Docopt fatal regression (not handled rename) has been fixed.
* Regression tests were added for docopt output.