### PR TITLE
Docs typo? minimal.m4 vs script.m4

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -133,14 +133,14 @@ We generate the script from the template:
 
 ::
 
-   bin/argbash minimal.m4 -o script.sh
+   bin/argbash minimal.m4 -o minimal.sh
 
 
 Now we launch it and the output is good!
 
 ::
 
-   ./script.sh posi-tional -o opt-ional --print
+   ./minimal.sh posi-tional -o opt-ional --print
 
    Positional arg value: posi-tional
    Optional arg --option value: opt-ional

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -133,7 +133,7 @@ We generate the script from the template:
 
 ::
 
-   bin/argbash script.m4 -o script.sh
+   bin/argbash minimal.m4 -o script.sh
 
 
 Now we launch it and the output is good!


### PR DESCRIPTION
In index.rst, it appears there's a typo, because we have this:

```
bin/argbash-init --pos positional-arg --opt option --opt-bool print minimal.m4
```

followed by this:

```
bin/argbash script.m4 -o script.sh
```

I made the smallest change required to make this work, but maybe you want to change them all to `minimal`?