### PR TITLE
supporting Docker Hub autobuild

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*
+!bin
+!doc
+!docker
+!resources
+!src
+!tests
+*.in
+*.md
+*.sh
+*.yml

--- a/docker/Dockerfile.in
+++ b/docker/Dockerfile.in
@@ -23,8 +23,8 @@ RUN apk add --no-cache \
 	bash
 
 # Install argbash from sources
-COPY    argbash/ /usr/src/argbash/
-COPY    entrypoint.sh /
+COPY [".", "/usr/src/argbash//"]
+COPY ["./docker/entrypoint.sh", "/"]
 
 WORKDIR /usr/src/argbash/resources/
 RUN     apk add --no-cache --virtual .build-dependencies \


### PR DESCRIPTION
Hello matejak

I'm not sure if you want to support Docker Hub autobuilds at all, but this quick hack would enable it. 

The oddities are:

- The *README.md* for the Docker image is contained in the *docker* subdirectory. However, Docker Hub currently does not support it and it looks for the README content always in the build context root directory. So some workaround must be chosen.

- Some adjustements in your primary **push approach** would be probably required (e.g. in *Makefile* and *handle_image.sh* files).

I've created a quick repository clone [accetto/argbash-docker](https://hub.docker.com/r/accetto/argbash-docker) where you can check it.

The Docker Hub's *autobuild context* should be set to `/` and the *Dockerfile path* to `docker/Docker.in`.

Btw, if you don't like the clone, I'll remove it.

Regards
accetto



