### PR TITLE
style: Group commands in optional arg parsing

### DIFF
--- a/src/stuff.m4
+++ b/src/stuff.m4
@@ -1269,7 +1269,7 @@ m4_define([_PASS_WHEN_GETOPT], [m4_ifnblank([$1], [m4_do(
 		[[[_next="${_key##-$1}"]],
 		[[if test -n "$_next" -a "$_next" != "$_key"]],
 		[[then]],
-		[_INDENT_()[begins_with_short_option "$_next" && shift && set -- "-$1" "-${_next}" "@S|@@" || die "The short option '$_key' can't be decomposed to ${_key:0:2} and -${_key:2}, because ${_key:0:2} doesn't accept value and '-${_key:2:1}' doesn't correspond to a short option."]],
+		[_INDENT_()[{ begins_with_short_option "$_next" && shift && set -- "-$1" "-${_next}" "@S|@@"; } || die "The short option '$_key' can't be decomposed to ${_key:0:2} and -${_key:2}, because ${_key:0:2} doesn't accept value and '-${_key:2:1}' doesn't correspond to a short option."]],
 		[[fi]]])],
 )])])
 


### PR DESCRIPTION
Found via shellcheck on input with an optional argument, which warns

    ^-- SC2015: Note that A && B || C is not if-then-else. C may run when A is true.

SC2015: https://www.shellcheck.net/wiki/SC2015