### PR TITLE
Get rid of include warnings

### DIFF
--- a/bin/argbash
+++ b/bin/argbash
@@ -156,7 +156,7 @@ parse_commandline()
 				_next="${_key##-c}"
 				if test -n "$_next" -a "$_next" != "$_key"
 				then
-					begins_with_short_option "$_next" && shift && set -- "-c" "-${_next}" "$@" || die "The short option '$_key' can't be decomposed to ${_key:0:2} and -${_key:2}, because ${_key:0:2} doesn't accept value and '-${_key:2:1}' doesn't correspond to a short option."
+					{ begins_with_short_option "$_next" && shift && set -- "-c" "-${_next}" "$@"; } || die "The short option '$_key' can't be decomposed to ${_key:0:2} and -${_key:2}, because ${_key:0:2} doesn't accept value and '-${_key:2:1}' doesn't correspond to a short option."
 				fi
 				;;
 			-I|--search)

--- a/bin/argbash-init
+++ b/bin/argbash-init
@@ -98,7 +98,7 @@ parse_commandline()
 				_next="${_key##-s}"
 				if test -n "$_next" -a "$_next" != "$_key"
 				then
-					begins_with_short_option "$_next" && shift && set -- "-s" "-${_next}" "$@" || die "The short option '$_key' can't be decomposed to ${_key:0:2} and -${_key:2}, because ${_key:0:2} doesn't accept value and '-${_key:2:1}' doesn't correspond to a short option."
+					{ begins_with_short_option "$_next" && shift && set -- "-s" "-${_next}" "$@"; } || die "The short option '$_key' can't be decomposed to ${_key:0:2} and -${_key:2}, because ${_key:0:2} doesn't accept value and '-${_key:2:1}' doesn't correspond to a short option."
 				fi
 				;;
 			--no-hints|--hints)

--- a/src/argbash-lib.m4
+++ b/src/argbash-lib.m4
@@ -1,16 +1,16 @@
 m4_define([INCLUDE_ACCORDING_TO_OUTPUT_TYPE],
-	[m4_include([output-$1.m4])])
+	[m4_include_once([output-$1.m4])])
 
 m4_ifndef([_OUTPUT_TYPE],
 	[m4_define([_OUTPUT_TYPE], [bash-script])])
 
 
-m4_include([list.m4])
-m4_include([constants.m4])
 m4_include([utilities.m4])
-m4_include([collectors.m4])
-m4_include([stuff.m4])
-m4_include([default_settings.m4])
+m4_include_once([list.m4])
+m4_include_once([constants.m4])
+m4_include_once([collectors.m4])
+m4_include_once([stuff.m4])
+m4_include_once([default_settings.m4])
 INCLUDE_ACCORDING_TO_OUTPUT_TYPE(_OUTPUT_TYPE)
 
 dnl These macros that are being undefined are not needed and they present a security threat when exposed during Argbash run

--- a/src/output-bash-script.m4
+++ b/src/output-bash-script.m4
@@ -1,8 +1,8 @@
-m4_include([function_generators.m4])
-m4_include([argument_value_types.m4])
-m4_include([env_vars.m4])
-m4_include([progs.m4])
-m4_include([value_validators.m4])
+m4_include_once([function_generators.m4])
+m4_include_once([argument_value_types.m4])
+m4_include_once([env_vars.m4])
+m4_include_once([progs.m4])
+m4_include_once([value_validators.m4])
 
 
 m4_define([_MAKE_DEFAULTS_TO_ALL_POSITIONAL_ARGUMENTS], [[no]])

--- a/src/output-completion.m4
+++ b/src/output-completion.m4
@@ -1,6 +1,6 @@
 dnl TODO: Basename determination: output filename, or input filename, or nothing.
-m4_include([argument_value_types.m4])
-m4_include([value_validators.m4])
+m4_include_once([argument_value_types.m4])
+m4_include_once([value_validators.m4])
 
 dnl Make somehow sure that the program name is translated to a valid shell function identifier
 m4_define([_TRANSLATE_BAD_CHARS], [m4_translit([[$1]], [-.], [__])])

--- a/src/output-docopt.m4
+++ b/src/output-docopt.m4
@@ -1,4 +1,4 @@
-m4_include([docopt.m4])
+m4_include_once([docopt.m4])
 
 
 dnl

--- a/src/output-manpage-defs.m4
+++ b/src/output-manpage-defs.m4
@@ -1,4 +1,4 @@
-m4_include([docopt.m4])
+m4_include_once([docopt.m4])
 
 dnl
 dnl $1: The macro call (the caller is supposed to pass [$0($@)])

--- a/src/output-manpage.m4
+++ b/src/output-manpage.m4
@@ -1,4 +1,4 @@
-m4_include([docopt.m4])
+m4_include_once([docopt.m4])
 
 dnl
 dnl $1: The macro call (the caller is supposed to pass [$0($@)])

--- a/src/output-posix-script.m4
+++ b/src/output-posix-script.m4
@@ -1,8 +1,8 @@
-m4_include([function_generators.m4])
-m4_include([argument_value_types.m4])
-m4_include([env_vars.m4])
-m4_include([progs.m4])
-m4_include([value_validators.m4])
+m4_include_once([function_generators.m4])
+m4_include_once([argument_value_types.m4])
+m4_include_once([env_vars.m4])
+m4_include_once([progs.m4])
+m4_include_once([value_validators.m4])
 
 
 dnl TODO: Can't do:

--- a/src/utilities.m4
+++ b/src/utilities.m4
@@ -1,4 +1,15 @@
-m4_include([list.m4])
+
+m4_set_delete([__FILES_ALREADY_INCLUDED__])
+m4_set_add([__FILES_ALREADY_INCLUDED__], __file__)
+dnl
+dnl $1: The filename to include
+m4_define([m4_include_once], [m4_do(
+	[m4_set_contains([__FILES_ALREADY_INCLUDED__], [$1], [], 
+		[m4_set_add([__FILES_ALREADY_INCLUDED__], [$1])m4_include([$1])])],
+)])
+
+
+m4_include_once([list.m4])
 
 
 m4_define([_ENDL_],

--- a/src/value_validators.m4
+++ b/src/value_validators.m4
@@ -1,4 +1,4 @@
-m4_include([function_generators.m4])
+m4_include_once([function_generators.m4])
 
 dnl
 dnl Define a validator for a particular type. Instead of using m4_define, use this:

--- a/tests/unittests/check-arguments.m4
+++ b/tests/unittests/check-arguments.m4
@@ -1,5 +1,6 @@
-m4_include([argbash-lib.m4])
-m4_include([test-support.m4])
+m4_include([utilities.m4])
+m4_include_once([argbash-lib.m4])
+m4_include_once([test-support.m4])
 
 dnl TODO PROBLEMS:
 dnl - defaults are quoted.

--- a/tests/unittests/check-env.m4
+++ b/tests/unittests/check-env.m4
@@ -1,5 +1,6 @@
-m4_include([argbash-lib.m4])
-m4_include([test-support.m4])
+m4_include([utilities.m4])
+m4_include_once([argbash-lib.m4])
+m4_include_once([test-support.m4])
 
 ARG_USE_ENV([OS_CLOUD], , [my blah help text])
 ARG_USE_ENV([BOMB], [default BOMB], [a, BOMB])

--- a/tests/unittests/check-indentation.m4
+++ b/tests/unittests/check-indentation.m4
@@ -1,7 +1,7 @@
-m4_include([list.m4])
 m4_include([utilities.m4])
-m4_include([argument_value_types.m4])
-m4_include([test-support.m4])
+m4_include_once([list.m4])
+m4_include_once([argument_value_types.m4])
+m4_include_once([test-support.m4])
 
 _SET_INDENT([x-])
 assert_equals(_INDENT_(0)y, y)

--- a/tests/unittests/check-list.m4
+++ b/tests/unittests/check-list.m4
@@ -1,5 +1,5 @@
-m4_include([list.m4])
-m4_include([test-support.m4])
+m4_include([utilities.m4])
+m4_include_once([test-support.m4])
 
 dnl If BOMB gets expanded, we will be noticed.
 assert_equals(m4_quote(m4_list_contents([lol])), [])

--- a/tests/unittests/check-types.m4
+++ b/tests/unittests/check-types.m4
@@ -1,5 +1,5 @@
 m4_include([utilities.m4])
-m4_include([test-support.m4])
+m4_include_once([test-support.m4])
 
 m4_define([CHECK], _CHECK_PASSED_ARGS_COUNT(2, 3, [[one], [two (opt.)]]))
 

--- a/tests/unittests/check-utils.m4
+++ b/tests/unittests/check-utils.m4
@@ -1,7 +1,6 @@
-m4_include([list.m4])
 m4_include([utilities.m4])
-m4_include([function_generators.m4])
-m4_include([test-support.m4])
+m4_include_once([function_generators.m4])
+m4_include_once([test-support.m4])
 
 m4_list_append([FOO], [one])
 m4_list_append([FOO], [two])


### PR DESCRIPTION
Don't trigger the include-related warnings by introducing an `m4_include_once` macro.