### PR TITLE
Make die work with nounset

### DIFF
--- a/src/function_generators.m4
+++ b/src/function_generators.m4
@@ -37,11 +37,10 @@ m4_define([_MAKE_DIE_FUNCTION], [MAKE_FUNCTION(
 		_INDENT_()[test -f "$_arg_infile" || _PRINT_HELP=yes die "Can't continue, have to supply file as an argument, got '$_arg_infile'" 4]],
 	[die],
 	[_JOIN_INDENTED(1,
-		[[test -n "$_ret" || _ret=1]],
-		[[test "$_PRINT_HELP" = yes && print_help >&2]],
+		[[test "${_PRINT_HELP:-no}" = yes && print_help >&2]],
 		[[echo "@S|@1" >&2]],
-		[[exit ${_ret}]])],
-	[_ret=@S|@2],
+		[[exit "${_ret}"]])],
+	[_ret="${2:-1}"],
 )])
 
 


### PR DESCRIPTION
I like to keep `set -euo pipefail` at the top of my scripts. This causes
a couple of errors with argbash's die function reading unset variables:

1. it sets a default for the exit code like in a way that
   unconditionally reads the second argument

    local _ret=$2  # <---- can fail if only one arg passed in
    test -n "$_ret" || _ret=1

2. it reads unconditionally from _PRINT_HELP, which may not be set

This commit changes both of these to use default values in parameter
expansion.  This construct is part of POSIX, and so should work in both
bash and posix mode.

Additionally fix a shellcheck quote warning.

Tested: Verified the generated die function works with nounset.