### PR TITLE
Add --in-place option

### DIFF
--- a/bin/argbash
+++ b/bin/argbash
@@ -8,6 +8,7 @@
 # DEFINE_SCRIPT_DIR()_DEFINE_SCRIPT_DIR([],[cd "$(dirname "${BASH_SOURCE[0]}")" && pwd])
 # ARG_POSITIONAL_SINGLE([input],[The input template file (pass '-' for stdin)])
 # ARG_OPTIONAL_SINGLE([output],[o],[Name of the output file (pass '-' for stdout)],[-])
+# ARG_OPTIONAL_BOOLEAN([in-place],[i],[Update a bash script in-place],[off])
 # ARG_OPTIONAL_SINGLE([type],[t],[Output type to generate],[bash-script])
 # ARG_OPTIONAL_BOOLEAN([library],[],[Whether the input file if the pure parsing library])
 # ARG_OPTIONAL_SINGLE([strip],[],[Determines what to have in the output],[none])
@@ -62,7 +63,7 @@ type()
 
 begins_with_short_option()
 {
-	local first_option all_short_options='otcIhv'
+	local first_option all_short_options='oitcIhv'
 	first_option="${1:0:1}"
 	test "$all_short_options" = "${all_short_options/$first_option/}" && return 1 || return 0
 }
@@ -72,6 +73,7 @@ _positionals=()
 _arg_input=
 # THE DEFAULTS INITIALIZATION - OPTIONALS
 _arg_output="-"
+_arg_in_place="off"
 _arg_type="bash-script"
 _arg_library="off"
 _arg_strip="none"
@@ -84,9 +86,10 @@ _arg_debug=
 print_help()
 {
 	printf '%s\n' "Argbash is an argument parser generator for Bash."
-	printf 'Usage: %s [-o|--output <arg>] [-t|--type <type>] [--(no-)library] [--strip <content>] [--(no-)check-typos] [-c|--(no-)commented] [-I|--search <arg>] [--debug <arg>] [-h|--help] [-v|--version] <input>\n' "$0"
+	printf 'Usage: %s [-o|--output <arg>] [-i|--(no-)in-place] [-t|--type <type>] [--(no-)library] [--strip <content>] [--(no-)check-typos] [-c|--(no-)commented] [-I|--search <arg>] [--debug <arg>] [-h|--help] [-v|--version] <input>\n' "$0"
 	printf '\t%s\n' "<input>: The input template file (pass '-' for stdin)"
 	printf '\t%s\n' "-o, --output: Name of the output file (pass '-' for stdout) (default: '-')"
+	printf '\t%s\n' "-i, --in-place, --no-in-place: Update a bash script in-place (off by default)"
 	printf '\t%s\n' "-t, --type: Output type to generate. Can be one of: 'bash-script', 'posix-script', 'manpage', 'manpage-defs', 'completion' and 'docopt' (default: 'bash-script')"
 	printf '\t%s\n' "--library, --no-library: Whether the input file if the pure parsing library (off by default)"
 	printf '\t%s\n' "--strip: Determines what to have in the output. Can be one of: 'none', 'user-content' and 'all' (default: 'none')"
@@ -118,6 +121,18 @@ parse_commandline()
 				;;
 			-o*)
 				_arg_output="${_key##-o}"
+				;;
+			-i|--no-in-place|--in-place)
+				_arg_in_place="on"
+				test "${1:0:5}" = "--no-" && _arg_in_place="off"
+				;;
+			-i*)
+				_arg_in_place="on"
+				_next="${_key##-i}"
+				if test -n "$_next" -a "$_next" != "$_key"
+				then
+					{ begins_with_short_option "$_next" && shift && set -- "-i" "-${_next}" "$@"; } || die "The short option '$_key' can't be decomposed to ${_key:0:2} and -${_key:2}, because ${_key:0:2} doesn't accept value and '-${_key:2:1}' doesn't correspond to a short option."
+				fi
 				;;
 			-t|--type)
 				test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
@@ -430,6 +445,11 @@ trap cleanup EXIT
 # If we are reading from stdout, then create a temp file
 if test "$infile" = '-'
 then
+	if test "$_arg_in_place" = 'on'
+	then
+		echo "Cannot use stdin input with --in-place option!" >&2
+		exit 1;
+	fi
 	infile=temp_in_$$
 	_files_to_clean+=("$infile")
 	cat > "$infile"
@@ -449,6 +469,9 @@ then
 fi
 
 test -f "$infile" || _PRINT_HELP=yes die "argument '$infile' is supposed to be a file!" 1
+if [ $_arg_in_place = on ]; then
+	_arg_output=$infile
+fi
 test -n "$_arg_output" || { echo "The output can't be blank - it is not a legal filename!" >&2; exit 1; }
 outfname="$_arg_output"
 autom4te --version > "$discard" 2>&1 || { echo "You need the 'autom4te' utility (it comes with 'autoconf'), if you have bash, that one is an easy one to get." 2>&1; exit 1; }
@@ -482,4 +505,5 @@ else
 	printf "%s\\n" "$output"
 fi
 
-# # ] <-- needed because of Argbash
+# #  <-- needed because of Argbash
+# ] <-- needed because of Argbash


### PR DESCRIPTION
When updating a tool created with argbash, it's common to want to
modify the arguments and regenerate it in-place. While this can be
done by passing `-o filename`, this is simpler.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>