### PR TITLE
Make argbash-docker to run as the user of host

### DIFF
--- a/docker/Dockerfile.in
+++ b/docker/Dockerfile.in
@@ -1,7 +1,7 @@
 FROM library/alpine:latest
 
 LABEL \
-	run="docker run -it --rm -v \"$(pwd):/work\" matejak/argbash my-template.m4 -o my-script.sh" \
+	run="docker run -it --rm -v \"$(pwd):/work\" -u \"$(id -u):$(id -g)\" matejak/argbash my-template.m4 -o my-script.sh" \
 	help="docker run -it --rm matejak/argbash -h" \
 	version="@VERSION@" \
 	vendor="matej.tyc@gmail.com" \

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,7 +33,7 @@ The sensible way how to use the `Argbash` image is to create a one-line shell sc
 
 | OS | script |
 | --- | --- |
-| Posix (e.g. Linux, MacOS) | `docker run -it --rm -e PROGRAM=argbash -v "$(pwd):/work" matejak/argbash "$@"` |
+| Posix (e.g. Linux, MacOS) | `docker run -it --rm -e PROGRAM=argbash -v "$(pwd):/work" -u "$(id -u):$(id -g)" matejak/argbash "$@"` |
 | Windows | `docker run -it --rm -e PROGRAM=argbash -v "%CD%:/work" matejak/argbash %*` |
 
 What happens here?
@@ -42,6 +42,7 @@ A container is created from the `matejak/argbash` image.
 * The `-t` option is needed for the output to be displayed.
 * The `-e PROGRAM=argbash` option is redundant and it basically affirms the container to invoke `argbash`. If you specify `PROGRAM=argbash-init`, `argbash-init` will be invoked instead, default program is `argbash`.
 * The `-v ...:/work` mounts the current directory to the working directory of the container, which is `/work`.
+* The `-u $(id -u):$(id -g)` makes the container run as the same user of the host machine, which allows `argbash` to replace files that were not created by it.
 * The `"$@"` or `%*` propagates any arguments given to this one-liner script to the `argbash` invocation in the container.
   Make sure that you use the `-o|--output` option - if you intend to use the Argbash output from stdout, the line endings will be of the DOS kind (i.e. `\r\n` instead of just `\n` - thanks to [Filip Filmar](https://github.com/filmil) who found this out).
 
@@ -54,9 +55,9 @@ Example
 Imagine that you want to download an example, edit it, and make it a full-fledged script with `argbash`.
 You obviously have to fire up `docker`, but then, you just create the one-liner, download the example, and proceed.
 
-```
-printf '%s\n' '#!/bin/bash' 'docker run -it --rm -v "$(pwd):/work" matejak/argbash "$@"' > argbash-docker
-printf '%s\n' '#!/bin/bash' 'docker run -it -e PROGRAM=argbash-init --rm -v "$(pwd):/work" matejak/argbash "$@"' > argbash-init-docker
+``` shell
+printf '%s\n' '#!/bin/bash' 'docker run -it --rm -v "$(pwd):/work" -u "$(id -u):$(id -g)" matejak/argbash "$@"' > argbash-docker
+printf '%s\n' '#!/bin/bash' 'docker run -it -e PROGRAM=argbash-init --rm -v "$(pwd):/work" -u "$(id -u):$(id -g)" matejak/argbash "$@"' > argbash-init-docker
 chmod a+x argbash-docker argbash-init-docker
 
 ./argbash-init-docker --pos positional-arg --opt optional-arg minimal.m4


### PR DESCRIPTION
This prevents `argbash-docker` from get permission denied when trying to replace files created by a user other than root. 

Example: 

1. You have a existing  `script.m4` and `script.sh` in your the repository.
2. You make changes to `script.m4` and call `argbash-docker script.m4 -o script.sh`. This will cause an error because `argbash-docker` is trying to write a file that is not owned by the user of `argbash-docker` container.