### PR TITLE
Increase flexibility of the help argument.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,9 @@ Buxfixes:
 *  Fixed incorrect permission of non-script output files (#104).
 *  Increased MacOS compatibility by removing terminator from the `chmod` invocation (#107).
 
+New features:
+*  Increased flexibility of the help option (#92).
+
 
 2.8.1 (2019-06-30)
 ------------------

--- a/doc/_static/wrapper-output-action.txt
+++ b/doc/_static/wrapper-output-action.txt
@@ -2,7 +2,7 @@ resources/examples/simple-wrapper.sh --glob '*.m4' ../src ../resources/examples 
 
 Contents of '../src' matching '*.m4':
 	argbash-1to2.m4: 1 kiB
-	argbash-init.m4: 5 kiB
+	argbash-init.m4: 6 kiB
 	argbash-lib.m4: 0 kiB
 	argbash.m4: 10 kiB
 	argument_value_types.m4: 5 kiB

--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -243,13 +243,21 @@ Special arguments
 * Help argument (a special case of an optional action argument):
   ::
 
-     ARG_HELP([short program description (optional)], [long program description (optional)])
+     ARG_HELP([short program description (optional)], [long program description (optional)],
+         [long option (optional, "help" by default)], [short option (optional, "h" by default)], [option description (optional, "Prints help" by default)])
 
-  This will generate the ``--help`` and ``-h`` action arguments that will print the usage information.
+  By default, it will generate the ``--help`` and ``-h`` action arguments that will print the usage information.
+  You can use the last three arguments to override the default help argument handling.
   Notice that the usage information is generated even if this macro is not used --- we print it when we think that there is something wrong with arguments that were passed.
 
   The long program description is a string quoted in double quotation marks (so you may use environmental variables in it) and additionally, occurrences of ``\n`` will be translated to a line break with indentation (use ``\\n`` to have the actual ``\n`` in the help description).
   If you want to have environmental variables and newlines, you have to make sure that the env variable contains literal newlines/tabs --- you can either use the ``foo=$'broken\nline'`` `pattern <http://stackoverflow.com/a/3182519>`_, or you can use quotes to define the variable so it contains real literal newlines / tabs.
+
+  Example invocation:
+
+  ::
+
+     ARG_HELP([My app], [Parses arguments ...\n... perfectly.], [], [?])
 
 * Version argument (a special case of an action argument):
   ::

--- a/src/collectors.m4
+++ b/src/collectors.m4
@@ -73,7 +73,7 @@ dnl Checks that the an argument is a correct short option arg
 dnl $1: The short option "string"
 dnl $2: The argument name
 m4_define([_CHECK_SHORT_OPTION_NAME_IS_OK], [m4_ifnblank([$1], [m4_do(
-		[m4_bmatch([$1], [^[0-9a-zA-z]$], ,
+		[m4_bmatch([$1], [^[0-9a-zA-z?]$], ,
 			[_COLLECTOR_FEEDBACK([The value of short option '$1' for argument '--$2' is not valid - it has to be either left blank, or exactly one character.]m4_ifnblank([$1], [[ (Yours has ]m4_len([$1])[ characters).]]))])],
 		[m4_set_contains([_ARGS_SHORT], [$1],
 			[_COLLECTOR_FEEDBACK([The short option '$1' (in definition of '--$2') is already used.])],
@@ -264,11 +264,19 @@ m4_define([_ARG_VERSION], [m4_do(
 dnl
 dnl $1: The main help message
 dnl $2: The bottom help message
-argbash_api([ARG_HELP], _CHECK_PASSED_ARGS_COUNT(1, 2)[m4_do(
+dnl $3: The help command's long option (optional)
+dnl $4: The help command's short option (optional)
+dnl $5: The help command's description (optional)
+argbash_api([ARG_HELP], _CHECK_PASSED_ARGS_COUNT(1, 5)[m4_do(
 	[dnl Skip help if we declare we don't want it
 ],
 	[[$0($@)]],
-	[_IF_W_FLAGS_DONT_CONTAIN([H], [_ARG_HELP([$1], [$2])])],
+	[_IF_W_FLAGS_DONT_CONTAIN(
+		[H], [_ARG_HELP([$1], [$2],
+		m4_default_quoted([$3], [help]),
+		m4_default_quoted([$4], [h]),
+		m4_default_quoted([$5], [Prints help]),
+	)])],
 )])
 
 
@@ -279,9 +287,9 @@ m4_define([_ARG_HELP], [m4_do(
 	[m4_define([_HELP_MSG], [m4_escape([$1])])],
 	[m4_define([_HELP_MSG_EX], [m4_escape([$2])])],
 	[_ARG_OPTIONAL_ACTION(
-		[help],
-		[h],
-		[Prints help],
+		[$3],
+		[$4],
+		[$5],
 		[print_help],
 	)],
 )])

--- a/src/stuff.m4
+++ b/src/stuff.m4
@@ -688,13 +688,20 @@ m4_define([_MAKE_OPTARG_SIMPLE_CASE_SECTION_IF_IT_MAKES_SENSE],
 			[_IF_ARG_ACCEPTS_VALUE([$3], , [_PICK_SIMPLE_CASE_STATEMENT_COMMENT($@)_MAKE_OPTARG_SIMPLE_CASE_SECTION($@)])])])])
 
 
+dnl
+dnl $1: Value to escape
+dnl Characters s.a. ? (the only one implemented) have special meaning in case statements,
+dnl so they need to be backslash-escaped.
+m4_define([_CASE_ESCAPE], [m4_bpatsubsts([[$1]], [\?], [\\?])])
+
+
 dnl TODO: We have to restrict case match for long options only if those long opts accept value.
 dnl We always match for --help - even if delim is = only.
 dnl And we also match for --no-that
 dnl And for -h*, since this is an action and argbash then ends (but maybe not, what if one has passed -hx, while -x is invalid?)
 m4_define([_MAKE_OPTARG_SIMPLE_CASE_SECTION], [m4_do(
 	[_INDENT_AND_END_CASE_MATCH(
-		[m4_ifblank([$2], [], [[-$2]])],
+		[m4_ifblank([$2], [], m4_dquote(_CASE_ESCAPE([-$2])))],
 		[_IF_ARG_IS_BOOLEAN([$3], [[--no-$1]])],
 		[_IF_ARG_ACCEPTS_VALUE([$3], [_IF_SPACE_IS_A_DELIMITER([[--$1]])], [[--$1]])])],
 	[m4_case([$3],
@@ -786,7 +793,7 @@ m4_define([_MAKE_OPTARG_LONGOPT_EQUALS_CASE_SECTION], [m4_do(
 
 m4_define([_MAKE_OPTARG_GETOPT_CASE_SECTION], [m4_do(
 	[_INDENT_AND_END_CASE_MATCH(
-		[[-$2*]])],
+		m4_dquote(-[]_CASE_ESCAPE([$2])*))],
 	[dnl Search for occurences of e.g. -ujohn and make sure that either -u accepts a value, or -j is a short option
 ],
 	[m4_case([$3],

--- a/tests/regressiontests/Makefile
+++ b/tests/regressiontests/Makefile
@@ -503,7 +503,7 @@ test-infinity-mixed: $(TESTDIR)/test-infinity-mixed.sh
 	$< 1 2 "3 1 4" 4 5 | grep -q 'POS_S=1,2,3 1 4,4,5,'
 	test -z "$(SHELLCHECK)" || $(SHELLCHECK) "$(TESTDIR)/test-infinity-mixed.sh"
 test-leftovers: $(TESTDIR)/test-leftovers.sh
-	$< -h | grep -q '\[-c|--cosi <arg>\] \[--(no-)fear\] \[-m|--more\] \[-h|--help\] <another> \.\.\. $$'
+	$< -? | grep -q '\[-c|--cosi <arg>\] \[--(no-)fear\] \[-m|--more\] \[-?|--hilfe\] <another> \.\.\. $$'
 	$< -c ours -m --more --more --no-fear "ours pos" left "o ver" | grep -q 'MORE=3,OPT_S=ours,FEAR=off,POS_S=ours pos,LEFTOVERS=left,o ver,'
 	test -z "$(SHELLCHECK)" || $(SHELLCHECK) "$(TESTDIR)/test-leftovers.sh"
 gen-test-infinity-dash: $(TESTDIR)/gen-test-infinity.m4 $(ARGBASH_BIN)

--- a/tests/regressiontests/make/tests/tests-base.m4
+++ b/tests/regressiontests/make/tests/tests-base.m4
@@ -293,7 +293,7 @@ ADD_TEST_BASH([test-infinity-mixed], [[
 ]])
 
 ADD_TEST_BASH([test-leftovers], [[
-	$< -h | grep -q '\[-c|--cosi <arg>\] \[--(no-)fear\] \[-m|--more\] \[-h|--help\] <another> \.\.\. $$'
+	$< -? | grep -q '\[-c|--cosi <arg>\] \[--(no-)fear\] \[-m|--more\] \[-?|--hilfe\] <another> \.\.\. $$'
 	$< -c ours -m --more --more --no-fear "ours pos" left "o ver" | grep -q 'MORE=3,OPT_S=ours,FEAR=off,POS_S=ours pos,LEFTOVERS=left,o ver,'
 ]])
 

--- a/tests/regressiontests/test-leftovers.m4
+++ b/tests/regressiontests/test-leftovers.m4
@@ -6,7 +6,7 @@
 # ARG_POSITIONAL_SINGLE([another])
 # ARG_LEFTOVERS([just leftovers])
 # ARG_DEFAULTS_POS()
-# ARG_HELP()
+# ARG_HELP(,, [hilfe], [?])
 # ARGBASH_GO
 
 # opening escape square bracket: [


### PR DESCRIPTION
- Allowed override of its name + short option.
- Allowed question mark '?' to be used as short option.

Fixes: #92