### PR TITLE
Prevent argbash-docker from returning CRLF line endings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Bianca Tamayo <hi@biancatamayo.me>
 Conduitry <git@chor.date>
+Felipe Santos
 Matěj Týč <matej.tyc@gmail.com>
 Stephen Gallagher <sgallagh@redhat.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,11 @@
 
 Buxfixes:
 
+New features:
+
+* Argbash in the container has no longer the terminal output limitation caused by the crlf line ending (#129). Thanks to Felipe Santos (@felipecrs)!.
+
+
 2.9.0 (2020-08-01)
 ------------------
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM library/alpine:latest
 
 LABEL \
-	run="docker run -it --rm -v \"$(pwd):/work\" -u \"$(id -u):$(id -g)\" matejak/argbash my-template.m4 -o my-script.sh" \
-	help="docker run -it --rm matejak/argbash -h" \
+	run="docker run --rm -v \"$(pwd):/work\" -u \"$(id -u):$(id -g)\" matejak/argbash my-template.m4 -o my-script.sh" \
+	help="docker run --rm matejak/argbash -h" \
 	version="@VERSION@" \
 	vendor="matej.tyc@gmail.com" \
 	release="1" \

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,18 +33,16 @@ The sensible way how to use the `Argbash` image is to create a one-line shell sc
 
 | OS | script |
 | --- | --- |
-| Posix (e.g. Linux, MacOS) | `docker run -it --rm -e PROGRAM=argbash -v "$(pwd):/work" -u "$(id -u):$(id -g)" matejak/argbash "$@"` |
-| Windows | `docker run -it --rm -e PROGRAM=argbash -v "%CD%:/work" matejak/argbash %*` |
+| Posix (e.g. Linux, MacOS) | `docker run --rm -e PROGRAM=argbash -v "$(pwd):/work" -u "$(id -u):$(id -g)" matejak/argbash "$@"` |
+| Windows | `docker run --rm -e PROGRAM=argbash -v "%CD%:/work" matejak/argbash %*` |
 
 What happens here?
 A container is created from the `matejak/argbash` image.
 
-* The `-t` option is needed for the output to be displayed.
 * The `-e PROGRAM=argbash` option is redundant and it basically affirms the container to invoke `argbash`. If you specify `PROGRAM=argbash-init`, `argbash-init` will be invoked instead, default program is `argbash`.
-* The `-v ...:/work` mounts the current directory to the working directory of the container, which is `/work`.
-* The `-u $(id -u):$(id -g)` makes the container run as the same user of the host machine, which allows `argbash` to replace files that were not created by it.
+* The `-v "$(pwd):/work"` or `-v "%CD%:/work"` mounts the current directory to the working directory of the container, which is `/work`.
+* The `-u "$(id -u):$(id -g)"` makes the container run as the same user of the host machine, which allows `argbash` to replace files that were not created by it.
 * The `"$@"` or `%*` propagates any arguments given to this one-liner script to the `argbash` invocation in the container.
-  Make sure that you use the `-o|--output` option - if you intend to use the Argbash output from stdout, the line endings will be of the DOS kind (i.e. `\r\n` instead of just `\n` - thanks to [Filip Filmar](https://github.com/filmil) who found this out).
 
 Note that as the container mounts the host directory, you may have issues with SELinux or similar measures enforcing proactive security.
 
@@ -56,8 +54,8 @@ Imagine that you want to download an example, edit it, and make it a full-fledge
 You obviously have to fire up `docker`, but then, you just create the one-liner, download the example, and proceed.
 
 ``` shell
-printf '%s\n' '#!/bin/bash' 'docker run -it --rm -v "$(pwd):/work" -u "$(id -u):$(id -g)" matejak/argbash "$@"' > argbash-docker
-printf '%s\n' '#!/bin/bash' 'docker run -it -e PROGRAM=argbash-init --rm -v "$(pwd):/work" -u "$(id -u):$(id -g)" matejak/argbash "$@"' > argbash-init-docker
+printf '%s\n' '#!/bin/bash' 'docker run --rm -v "$(pwd):/work" -u "$(id -u):$(id -g)" matejak/argbash "$@"' > argbash-docker
+printf '%s\n' '#!/bin/bash' 'docker run --rm -e PROGRAM=argbash-init -v "$(pwd):/work" -u "$(id -u):$(id -g)" matejak/argbash "$@"' > argbash-init-docker
 chmod a+x argbash-docker argbash-init-docker
 
 ./argbash-init-docker --pos positional-arg --opt optional-arg minimal.m4

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,19 +3,4 @@
 LAUNCH="argbash"
 test "$PROGRAM" = 'argbash-init' && LAUNCH="argbash-init" || true
 
-encountered_output_option=no
-for arg in "$@"; do
-	if printf "%s" "$arg" | grep -q -e '^\(-o\|--output\)\>'; then
-		encountered_output_option=yes
-		break
-	fi
-done
-
 "${LAUNCH}" "$@"
-
-if test "$encountered_output_option" != yes; then
-	echo '# It seems that you use the output to stdout.' >&2
-	echo '# Beware, docker is likely to change line endings to DOS line endings.' >&2
-	echo '# This will make the script not executable on Unixes, unless you convert \r\n to \n' >&2
-	echo '# Use the -o|--output option to save the output to a file.' >&2
-fi


### PR DESCRIPTION
This PR is basically #131 plus attribution.

---

We basically do not use `-it` on `docker run`. As long as we don't need
any interactive terminal, we're good.

And it seems that interactive terminal aren't being used anywhere.

Fixes #129 