### PR TITLE
argbash-init is able to handle empty string as the only argument

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@
 
 Buxfixes:
 
+* `argbash-init` is able to handle empty string as the only argument without being puzzled (#130).
+
 New features:
 
 * Argbash in the container has no longer the terminal output limitation caused by the crlf line ending (#129). Thanks to Felipe Santos (@felipecrs)!.

--- a/src/argbash-init.m4
+++ b/src/argbash-init.m4
@@ -215,6 +215,8 @@ do_stuff()
 }
 
 outfname="$_arg_output"
+# we canonicize the empty string input to output filename to the dash
+test -n "$outfname" || outfname='-'
 test "$outfname" = "-" -a "$_arg_separate" -gt 0 && die "If you want to separate parsing and script body, you have to specify the outname, stdout doesn't work."
 
 if test "$outfname" = '-'


### PR DESCRIPTION
It treats it as if it was given a dash.

Fixes: #130