### PR TITLE
argbash-defs: add in-place option to avoid error message

### DIFF
--- a/resources/argbash-defs.rst
+++ b/resources/argbash-defs.rst
@@ -12,6 +12,8 @@
 
 .. |OPTION_OUTPUT| replace:: \
 
+.. |OPTION_IN_PLACE| replace:: \
+
 .. |OPTION_TYPE| replace:: Check out the documentation to learn about all argbash capabilities that are supported.
 
 .. |OPTION_LIBRARY| replace:: This option is deprecated and it is the same as ``--strip user-content``.


### PR DESCRIPTION
rst2man shows an error message when converting from rst to man.

> rst2man argbash.rst | gzip > argbash.1.gz
> argbash.rst:42: (ERROR/3) Undefined substitution referenced: "OPTION_IN_PLACE".

To avoid this error message, add the in-place option in argbash-defs.rst file.
