### PR TITLE
Fix false positives in shellcheck tests

### DIFF
--- a/tests/regressiontests/test-env-base.m4
+++ b/tests/regressiontests/test-env-base.m4
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# SC2317: Command appears to be unreachable
+# When there are only action optional arguments and no positional ones, the shift statement can be omitted.
+# The check smells risky, and its value is very low.
+# shellcheck disable=SC2317
+#
 # ARG_USE_ENV([ENVI_FOO], [def,ault], [A sample env, variable])
 # ARG_USE_ENV([ENVI_BAR], [], [A sample env, variable])
 # ARG_HELP()

--- a/tests/regressiontests/test-env-simple.m4
+++ b/tests/regressiontests/test-env-simple.m4
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# SC2317: Command appears to be unreachable
+# When there are only action optional arguments and no positional ones, the shift statement can be omitted.
+# The check smells risky, and its value is very low.
+# shellcheck disable=SC2317
+#
 # ARG_USE_ENV([ENVI_FOO], [def,ault])
 # ARG_HELP()
 # ARGBASH_GO

--- a/tests/regressiontests/test-prog.m4
+++ b/tests/regressiontests/test-prog.m4
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+# SC2317: Command appears to be unreachable
+# When there are only action optional arguments and no positional ones, the shift statement can be omitted.
+# The check smells risky, and its value is very low.
+# shellcheck disable=SC2317
+#
 # ARG_VERSION([echo "$0 FOO"])
 # ARG_USE_PROGRAM([fulala], [FULALA], [fulala doesnt exist], [Testing program m4_fatal(BOOM!)])
 # ARG_HELP([Testing program m4_fatal(BOOM!)], [m4_fatal([CRASH!])])

--- a/tests/regressiontests/test-progs.m4
+++ b/tests/regressiontests/test-progs.m4
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+# SC2317: Command appears to be unreachable
+# When there are only action optional arguments and no positional ones, the shift statement can be omitted.
+# The check smells risky, and its value is very low.
+# shellcheck disable=SC2317
+#
 # ARG_VERSION([echo "$0 FOO"])
 # ARG_USE_PROGRAM([fulala], [FULALA], [fulala doesnt exist], [Testing program m4_fatal(BOOM!)])
 # ARG_USE_PROGRAM([make], [MAKE], [GNU make missing], [GNU make - utility used for automation])


### PR DESCRIPTION
Shellcheck became very smart, and it can detect that if there are only action optional args that exit upon call, there is no need for a 'for' to loop through args and, specifically, for 'shift' after 'case'.