### PR TITLE
Show basename of script in usage text

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Kevin Stravers <kevin@stravers.net>
 Matěj Týč <matej.tyc@gmail.com>
 Nicola Lunghi <nick83ola@gmail.com>
 Stephen Gallagher <sgallagh@redhat.com>
+Hannes Leutloff <hannes.leutloff@yeldirium.de>

--- a/bin/argbash
+++ b/bin/argbash
@@ -86,7 +86,7 @@ _arg_debug=
 print_help()
 {
 	printf '%s\n' "Argbash is an argument parser generator for Bash."
-	printf 'Usage: %s [-o|--output <arg>] [-i|--(no-)in-place] [-t|--type <type>] [--(no-)library] [--strip <content>] [--(no-)check-typos] [-c|--(no-)commented] [-I|--search <arg>] [--debug <arg>] [-h|--help] [-v|--version] <input>\n' "$0"
+	printf 'Usage: %s [-o|--output <arg>] [-i|--(no-)in-place] [-t|--type <type>] [--(no-)library] [--strip <content>] [--(no-)check-typos] [-c|--(no-)commented] [-I|--search <arg>] [--debug <arg>] [-h|--help] [-v|--version] <input>\n' "$(basename "$0")"
 	printf '\t%s\n' "<input>: The input template file (pass '-' for stdin)"
 	printf '\t%s\n' "-o, --output: Name of the output file (pass '-' for stdout) (default: '-')"
 	printf '\t%s\n' "-i, --in-place, --no-in-place: Update a bash script in-place (off by default)"

--- a/bin/argbash-1to2
+++ b/bin/argbash-1to2
@@ -42,7 +42,7 @@ _arg_output=""
 print_help()
 {
 	printf '%s\n' "Convert a template for argbash>=1,<2 to argbash>=2,<3"
-	printf 'Usage: %s [-o|--output <arg>] [-v|--version] [-h|--help] <input-1> [<input-2>] ... [<input-n>] ...\n' "$0"
+	printf 'Usage: %s [-o|--output <arg>] [-v|--version] [-h|--help] <input-1> [<input-2>] ... [<input-n>] ...\n' "$(basename "$0")"
 	printf '\t%s\n' "<input>: The input file to transform"
 	printf '\t%s\n' "-o, --output: Name of the output file (pass '-' for stdout and empty string for the same as input file) (default: '""')"
 	printf '\t%s\n' "-v, --version: Prints version"

--- a/bin/argbash-init
+++ b/bin/argbash-init
@@ -66,7 +66,7 @@ _arg_mode="default"
 print_help()
 {
 	printf '%s\n' "Make a template for scripts."
-	printf 'Usage: %s [-s|--separate] [--(no-)hints] [--pos <arg>] [--opt <arg>] [--opt-bool <arg>] [-m|--mode <MODE>] [-v|--version] [-h|--help] [<output>]\n' "$0"
+	printf 'Usage: %s [-s|--separate] [--(no-)hints] [--pos <arg>] [--opt <arg>] [--opt-bool <arg>] [-m|--mode <MODE>] [-v|--version] [-h|--help] [<output>]\n' "$(basename "$0")"
 	printf '\t%s\n' "<output>: Name of the output template (default: '-')"
 	printf '\t%s\n' "-s, --separate: Separate the parsing logic (specify two times for complete separation)"
 	printf '\t%s\n' "--hints, --no-hints: Whether to write hints to the script template (off by default)"

--- a/src/stuff.m4
+++ b/src/stuff.m4
@@ -417,7 +417,7 @@ m4_define([_MAKE_HELP], [MAKE_FUNCTION(
 		[dnl If we have optionals, display them like [--opt1 arg] [--(no-)opt2] ... according to their type. @<:@ becomes square bracket at the end of processing
 ],
 		[_MAKE_HELP_SYNOPSIS([$1])],
-		[\n' "@S|@0"_ENDL_()],
+		[\n' "$(basename "@S|@0")"_ENDL_()],
 		[_IF_HAVE_POSITIONAL_ARGS([_MAKE_HELP_FUNCTION_POSITIONAL_PART])],
 		[dnl If we have 0 optional args, don't do anything (FOR loop would assert, 0 < 1)
 ],

--- a/tests/regressiontests/Makefile
+++ b/tests/regressiontests/Makefile
@@ -266,6 +266,7 @@ basic: $(TESTDIR)/basic.sh
 	grep -q "local _key$$" $<
 	$< -h | grep -q 'P percent: %'
 	$< -h | grep -q 'O percent: %'
+	$< -h | grep -q 'Usage: $(notdir $<) '
 	! $< -h | grep -qe '\[--\]'
 	test -z "$(SHELLCHECK)" || $(SHELLCHECK) "$(TESTDIR)/basic.sh"
 basic-dash: $(TESTDIR)/basic-dash.sh
@@ -275,6 +276,7 @@ basic-dash: $(TESTDIR)/basic-dash.sh
 	$< LOO -b | grep -q BOOL=off,
 	$< -h | grep -q 'P percent: %'
 	$< -h | grep -q 'O percent: %'
+	$< -h | grep -q 'Usage: $(notdir $<) '
 	$< -h | grep -qe '\[--\]'
 	test -z "$(SHELLCHECK)" || $(SHELLCHECK) "$(TESTDIR)/basic-dash.sh"
 test-void: $(TESTDIR)/test-void.sh

--- a/tests/regressiontests/make/tests/tests-base.m4
+++ b/tests/regressiontests/make/tests/tests-base.m4
@@ -9,6 +9,7 @@ ADD_TEST_BASH([basic], [[
 	grep -q "local _key$$" $<
 	$< -h | grep -q 'P percent: %'
 	$< -h | grep -q 'O percent: %'
+	$< -h | grep -q 'Usage: $(notdir $<) '
 	! $< -h | grep -qe '\[--\]'
 ]])
 
@@ -20,6 +21,7 @@ ADD_TEST_DASH([basic], [[
 	$< LOO -b | grep -q BOOL=off,
 	$< -h | grep -q 'P percent: %'
 	$< -h | grep -q 'O percent: %'
+	$< -h | grep -q 'Usage: $(notdir $<) '
 	$< -h | grep -qe '\[--\]'
 ]])
 


### PR DESCRIPTION
This is an implementation of my suggestion in #202.
The formatting follows the suggestions from shellcheck to always quote variables and expansions results with unforeseeable contents.

I gotta admit, my m4 is a bit rusty.
I found out how to add the `basename`, but I can't wrap my head around the tests, so I didn't touch them.
Sorry for that.

But I ran the tests locally and they all passed.
The scripts `argbash`, `argbash-init` and `arbash-1to2` were regenerated with the new usage text.

<details><summary>Output of `make -B ../tests/regressiontests/Makefile && make check ARGBASH_EXEC=argbash ARGBASH_INIT_EXEC=argbash-init`</summary>
<p>

```
autom4te -l m4sugar -I ../tests/regressiontests/make ../tests/regressiontests/make/Makefile.m4 -o ../tests/regressiontests/Makefile
make: '../tests/regressiontests/Makefile' is up to date.
ARGBASH_INTENDED_DESTINATION="../bin/argbash" bash ../bin/argbash ../src/argbash.m4 -o argbash.temp && mv argbash.temp ../bin/argbash
../bin/argbash ../src/argbash-init.m4 -o ../bin/argbash-init
argbash ../src/argbash-1to2.m4 -o ../bin/argbash-1to2
make unittests
make[1]: Entering directory '/home/yeldir/querbeet/workspace/private/projects/argbash/resources'
autom4te -l m4sugar -I ../src/ -I ../tests/unittests ../tests/unittests/check-arguments.m4 && autom4te -l m4sugar -I ../src/ -I ../tests/unittests ../tests/unittests/check-env.m4 && autom4te -l m4sugar -I ../src/ -I ../tests/unittests ../tests/unittests/check-indentation.m4 && autom4te -l m4sugar -I ../src/ -I ../tests/unittests ../tests/unittests/check-list.m4 && autom4te -l m4sugar -I ../src/ -I ../tests/unittests ../tests/unittests/check-types.m4 && autom4te -l m4sugar -I ../src/ -I ../tests/unittests ../tests/unittests/check-utils.m4 && true
../src/argbash-lib.m4:8: warning: file 'utilities.m4' included several times
../src/utilities.m4:12: warning: file 'list.m4' included several times
../src/argbash-lib.m4:8: warning: file 'utilities.m4' included several times
../src/utilities.m4:12: warning: file 'list.m4' included several times
make[1]: Leaving directory '/home/yeldir/querbeet/workspace/private/projects/argbash/resources'
make regressiontests
make[1]: Entering directory '/home/yeldir/querbeet/workspace/private/projects/argbash/resources'
argbash ../tests/regressiontests/basic.m4 -o ../tests/regressiontests/basic.sh
argbash ../tests/regressiontests/basic.sh -o ../tests/regressiontests/basic2.sh
diff -q ../tests/regressiontests/basic.sh ../tests/regressiontests/basic2.sh
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/basic.sh"
../tests/regressiontests/basic.sh LOO | grep -q 'POS_S=LOO',
../tests/regressiontests/basic.sh "LOO BAR" | grep -q 'POS_S=LOO BAR,'
../tests/regressiontests/basic.sh -b LOO | grep -q BOOL=on,
../tests/regressiontests/basic.sh LOO | grep -q BOOL=off,
../tests/regressiontests/basic.sh LOO | grep -q 'OPT_S=opt_arg_default lolo',
../tests/regressiontests/basic.sh LOO UFTA | grep -q 'POS_OPT=UFTA,'
../tests/regressiontests/basic.sh LOO | grep -q 'OPT_INCR=2,'
../tests/regressiontests/basic.sh -ii LOO | grep -q 'OPT_INCR=4,'
../tests/regressiontests/basic.sh -h | grep -- pos_arg | grep -q pos_arg_help
../tests/regressiontests/basic.sh -h | grep -- pos-opt | grep -q @pos-opt-arg@
../tests/regressiontests/basic.sh -h | grep -q ' \[<pos-opt>\]'
../tests/regressiontests/basic.sh LOO --opt_arg "PoS sob" | grep -q 'OPT_S=PoS sob,'
../tests/regressiontests/basic.sh --opt_arg PoS LOO | grep -q OPT_S=PoS,
../tests/regressiontests/basic.sh --opt_arg="PoS sob" LOO | grep -q 'OPT_S=PoS sob,'
../tests/regressiontests/basic.sh LOO -b | grep -q BOOL=on,
../tests/regressiontests/basic.sh LOO --boo_l | grep -q BOOL=on,
../tests/regressiontests/basic.sh LOO --boo_l --boo_l | grep -q 'POS_OPT=pos_opt_default lala,'
../tests/regressiontests/basic.sh --no-boo_l LOO | grep -q BOOL=off,
../tests/regressiontests/basic.sh --opt-incr -i LOO | grep -q 'OPT_INCR=4,'
../tests/regressiontests/basic.sh LOO --opt-incr | grep -q 'OPT_INCR=3,'
../tests/regressiontests/reverse ../tests/regressiontests/basic.sh LOO --opt_arg 2> /dev/null
grep -q "local _key$" ../tests/regressiontests/basic.sh
../tests/regressiontests/basic.sh -h | grep -q 'P percent: %'
../tests/regressiontests/basic.sh -h | grep -q 'O percent: %'
! ../tests/regressiontests/basic.sh -h | grep -qe '\[--\]'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/basic.sh"
argbash ../tests/regressiontests/test-void.m4 -o ../tests/regressiontests/test-void.sh
! grep -q 'die' ../tests/regressiontests/test-void.sh
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-void.sh"
argbash ../tests/regressiontests/call-salone.m4 -o ../tests/regressiontests/call-salone.sh
../tests/regressiontests/call-salone.sh LOO | grep -q 'POS_S=LOO',
../tests/regressiontests/call-salone.sh "LOO BAR" | grep -q 'POS_S=LOO BAR,'
../tests/regressiontests/call-salone.sh -b LOO | grep -q BOOL=on,
../tests/regressiontests/call-salone.sh LOO | grep -q BOOL=off,
../tests/regressiontests/call-salone.sh LOO | grep -q 'OPT_S=opt_arg_default lolo',
../tests/regressiontests/call-salone.sh LOO UFTA | grep -q 'POS_OPT=UFTA,'
../tests/regressiontests/call-salone.sh LOO | grep -q 'OPT_INCR=2,'
../tests/regressiontests/call-salone.sh -ii LOO | grep -q 'OPT_INCR=4,'
../tests/regressiontests/call-salone.sh -h | grep -- pos_arg | grep -q pos_arg_help
../tests/regressiontests/call-salone.sh -h | grep -- pos-opt | grep -q @pos-opt-arg@
../tests/regressiontests/call-salone.sh -h | grep -q ' \[<pos-opt>\]'
../tests/regressiontests/call-salone.sh LOO --opt_arg "PoS sob" | grep -q 'OPT_S=PoS sob,'
../tests/regressiontests/call-salone.sh --opt_arg PoS LOO | grep -q OPT_S=PoS,
../tests/regressiontests/call-salone.sh --opt_arg="PoS sob" LOO | grep -q 'OPT_S=PoS sob,'
../tests/regressiontests/call-salone.sh LOO -b | grep -q BOOL=on,
../tests/regressiontests/call-salone.sh LOO --boo_l | grep -q BOOL=on,
../tests/regressiontests/call-salone.sh LOO --boo_l --boo_l | grep -q 'POS_OPT=pos_opt_default lala,'
../tests/regressiontests/call-salone.sh --no-boo_l LOO | grep -q BOOL=off,
../tests/regressiontests/call-salone.sh --opt-incr -i LOO | grep -q 'OPT_INCR=4,'
../tests/regressiontests/call-salone.sh LOO --opt-incr | grep -q 'OPT_INCR=3,'
../tests/regressiontests/reverse ../tests/regressiontests/call-salone.sh LOO --opt_arg 2> /dev/null
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/call-salone.sh"
argbash ../tests/regressiontests/test-most.m4 -o ../tests/regressiontests/test-most.sh
../tests/regressiontests/test-most.sh -h | grep -q '<pos-more1-1> <pos-more1-2> \[<pos-more2-1>\] \[<pos-more2-2>\]'
../tests/regressiontests/test-most.sh xx yy | grep -q "POS_MORE1=xx yy,POS_MORE2=hu lu,"
../tests/regressiontests/test-most.sh xx yy zz aa | grep -q "POS_MORE1=xx yy,POS_MORE2=zz aa,"
../tests/regressiontests/test-most.sh -h | grep -q '<pos-more1-1> <pos-more1-2> \[<pos-more2-1>\] \[<pos-more2-2>\]'
../tests/regressiontests/test-most.sh -h | grep -q '<pos-more1>: @pos-more1-arg@'
../tests/regressiontests/test-most.sh -h | grep -q "<pos-more2>: @pos-more2-arg@ (defaults for <pos-more2-1> to <pos-more2-2> respectively: 'hu' and 'lu')"
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-most.sh"
argbash ../tests/regressiontests/test-more.m4 -o ../tests/regressiontests/test-more.sh
../tests/regressiontests/test-more.sh LOO x | grep -q "POS_S=LOO,POS_MORE=x f\[o\]o ba,r,"
../tests/regressiontests/test-more.sh LOO lul laa | grep -q "POS_S=LOO,POS_MORE=lul laa ba,r,"
../tests/regressiontests/test-more.sh LOO laa bus kus | grep -q "POS_S=LOO,POS_MORE=laa bus kus",
ERROR="namely: 'pos-arg' and 'pos-more'" ../tests/regressiontests/reverse ../tests/regressiontests/test-more.sh
grep -q '^              _positionals' ../tests/regressiontests/test-more.sh
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-more.sh"
argbash ../tests/regressiontests/test-onlypos.m4 -o ../tests/regressiontests/test-onlypos.sh
../tests/regressiontests/reverse grep -q case ../tests/regressiontests/test-onlypos.sh
../tests/regressiontests/test-onlypos.sh LOO | grep -q POS_S=LOO,POS_OPT=pos-default,
../tests/regressiontests/test-onlypos.sh LOO ar,guma | grep -q POS_S=LOO,POS_OPT=ar,guma,
ERROR=spurious ../tests/regressiontests/reverse ../tests/regressiontests/test-onlypos.sh one two three
ERROR='between 1 and 2' ../tests/regressiontests/reverse ../tests/regressiontests/test-onlypos.sh one two three
ERROR='Not enough' ../tests/regressiontests/reverse ../tests/regressiontests/test-onlypos.sh
! grep -q '^_arg_pos_arg=$' ../tests/regressiontests/test-onlypos.sh
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-onlypos.sh"
argbash ../tests/regressiontests/test-onlypos-declared.m4 -o ../tests/regressiontests/test-onlypos-declared.sh
../tests/regressiontests/reverse grep -q case ../tests/regressiontests/test-onlypos-declared.sh
../tests/regressiontests/test-onlypos-declared.sh LOO | grep -q POS_S=LOO,POS_OPT=pos-default,
../tests/regressiontests/test-onlypos-declared.sh LOO ar,guma | grep -q POS_S=LOO,POS_OPT=ar,guma,
ERROR=spurious ../tests/regressiontests/reverse ../tests/regressiontests/test-onlypos-declared.sh one two three
ERROR='between 1 and 2' ../tests/regressiontests/reverse ../tests/regressiontests/test-onlypos-declared.sh one two three
ERROR='Not enough' ../tests/regressiontests/reverse ../tests/regressiontests/test-onlypos-declared.sh
grep -q '^_arg_pos_arg=$' ../tests/regressiontests/test-onlypos-declared.sh
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-onlypos-declared.sh"
argbash ../tests/regressiontests/test-onlyopt.m4 -o ../tests/regressiontests/test-onlyopt.sh
grep -q '^    esac$' ../tests/regressiontests/test-onlyopt.sh
! grep -q '^    ' ../tests/regressiontests/test-onlyopt.sh
../tests/regressiontests/reverse grep -q POSITION ../tests/regressiontests/test-onlyopt.sh
../tests/regressiontests/test-onlyopt.sh -o "PoS sob" | grep -q 'OPT_S=PoS sob,'
../tests/regressiontests/test-onlyopt.sh -B | grep -q 'BOOL=on'
../tests/regressiontests/test-onlyopt.sh -i | grep -q 'OPT_INCR=3,'
../tests/regressiontests/test-onlyopt.sh -i -i | grep -q 'OPT_INCR=4,'
! ../tests/regressiontests/test-onlyopt.sh -h | grep -q -e '-B,'
../tests/regressiontests/reverse ../tests/regressiontests/test-onlyopt.sh LOO 2> /dev/null
../tests/regressiontests/test-onlyopt.sh --opt-arg PoS | grep -q OPT_S=PoS,
../tests/regressiontests/test-onlyopt.sh --opt-arg "PoS sob" | grep -q 'OPT_S=PoS sob,'
../tests/regressiontests/test-onlyopt.sh --boo_l | grep -q 'BOOL=on'
../tests/regressiontests/test-onlyopt.sh --no-boo_l | grep -q 'BOOL=off'
../tests/regressiontests/test-onlyopt.sh -r /usr/lib --opt-repeated /usr/local/lib | grep -q 'ARG_REPEATED=/usr/lib /usr/local/lib,'
../tests/regressiontests/test-onlyopt.sh -h | grep -q -e '-B|--(no-)boo_l'
../tests/regressiontests/test-onlyopt.sh -h | grep -q -e '-i|--incrx'
../tests/regressiontests/test-onlyopt.sh -h | grep -q -e '-i, --incrx'
../tests/regressiontests/test-onlyopt.sh -h | grep -q -e '-o|--opt-arg <arg>'
../tests/regressiontests/test-onlyopt.sh -h | grep -q -e '-o, --opt-arg: @opt-arg@'
../tests/regressiontests/test-onlyopt.sh -h | grep -q -e '-r|--opt-repeated'
../tests/regressiontests/test-onlyopt.sh -h | grep -q -e '-r, --opt-repeated:'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-onlyopt.sh"
argbash ../tests/regressiontests/test-standalone.m4 -o ../tests/regressiontests/test-standalone.sh --strip user-content
argbash ../tests/regressiontests/test-standalone.sh -o ../tests/regressiontests/test-standalone2.sh --strip user-content
diff -q ../tests/regressiontests/test-standalone.sh ../tests/regressiontests/test-standalone2.sh
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-standalone.sh"
../tests/regressiontests/../../bin/argbash-1to2 ../tests/regressiontests/test-ddash-old.m4 -o ../tests/regressiontests/test-ddash.m4
argbash ../tests/regressiontests/test-ddash.m4 -o ../tests/regressiontests/test-ddash.sh
../tests/regressiontests/test-ddash.sh --boo_l | grep -q 'BOOL=on,'
../tests/regressiontests/test-ddash.sh -- --boo_l | grep -q 'BOOL=off,'
../tests/regressiontests/test-ddash.sh -- --boo_l | grep -q 'POS_OPT=--boo_l,'
../tests/regressiontests/test-ddash.sh -- --help | grep -q 'POS_OPT=--help,'
../tests/regressiontests/test-ddash.sh -- | grep -q 'POS_OPT=pos-default,'
../tests/regressiontests/test-ddash.sh -- --| grep -q 'POS_OPT=--,'
ERROR=spurious  ../tests/regressiontests/reverse ../tests/regressiontests/test-ddash.sh -- foo bar
ERROR=bar       ../tests/regressiontests/reverse ../tests/regressiontests/test-ddash.sh -- foo bar
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-ddash.sh"
argbash ../tests/regressiontests/test-simple.m4 -o ../tests/regressiontests/test-simple.sh
../tests/regressiontests/test-simple.sh pos | grep -q 'OPT_S=x,POS_S=pos,'
../tests/regressiontests/test-simple.sh -o 'uf ta' pos | grep -q 'OPT_S=uf ta,POS_S=pos,'
../tests/regressiontests/test-simple.sh -h | grep -q 'END-$'
../tests/regressiontests/test-simple.sh -h | grep -q '^\s*-BEGIN'
../tests/regressiontests/test-simple.sh -h | grep -q '^         -BEGIN'
../tests/regressiontests/test-simple.sh -h | grep -q -v '^\s*-BEGIN2'
../tests/regressiontests/test-simple.sh -h | grep -q -v 'END2-$'
../tests/regressiontests/test-simple.sh -h | grep -q '"line 2" END-\\n'
../tests/regressiontests/test-simple.sh -h | grep -q '^         -PBEGIN'
../tests/regressiontests/test-simple.sh -h | grep -q 'PEND-$'
grep -q '^              esac' ../tests/regressiontests/test-simple.sh
grep -q '^                      \*)' ../tests/regressiontests/test-simple.sh
ERROR=spurious  ../tests/regressiontests/reverse ../tests/regressiontests/test-simple.sh -- one two
ERROR="last one was: 'two'"     ../tests/regressiontests/reverse ../tests/regressiontests/test-simple.sh one two
ERROR="expect exactly 1"        ../tests/regressiontests/reverse ../tests/regressiontests/test-simple.sh one two
ERROR="[Nn]ot enough"   ../tests/regressiontests/reverse ../tests/regressiontests/test-simple.sh
ERROR="require exactly 1"       ../tests/regressiontests/reverse ../tests/regressiontests/test-simple.sh
../tests/regressiontests/test-simple.sh pos -o 'uf ta' | grep -q 'OPT_S=uf ta,POS_S=pos,'
../tests/regressiontests/test-simple.sh pos -o 'uf ta' --print-optionals | grep -q '_supplied_arg_prefix=1,_supplied_arg_print_optionals=1,_supplied_arg_la=0,_supplied_arg_not_supplied=x'
../tests/regressiontests/test-simple.sh pos -o 'uf ta' --print-optionals --la x | grep -q '_supplied_arg_prefix=1,_supplied_arg_print_optionals=1,_supplied_arg_la=1,_supplied_arg_not_supplied=x'
../tests/regressiontests/test-simple.sh pos -o 'uf ta' --print-optionals --la x --not-supplied | grep -q '_supplied_arg_prefix=1,_supplied_arg_print_optionals=1,_supplied_arg_la=1,_supplied_arg_not_supplied=x'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-simple.sh"
sed -e 's/ARGBASH_GO/ARGBASH_PREPARE/' ../tests/regressiontests/basic.m4 > ../tests/regressiontests/test-diy-noop.m4
../tests/regressiontests/../../bin/argbash -c -o "../tests/regressiontests/test-diy-noop.sh" "../tests/regressiontests/test-diy-noop.m4"
../tests/regressiontests/test-diy-noop.sh LOO --opt_arg > /dev/null
../tests/regressiontests/test-diy-noop.sh LOO 1 2 3 3 > /dev/null
../tests/regressiontests/test-diy-noop.sh > /dev/null
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-diy-noop.sh"
sed -e "s/#.*\[$/&\n$(grep -e '#  \S' "../tests/regressiontests/test-diy-noop.sh" | sed -e 's/^#  //' | tr '\n' ';')/" ../tests/regressiontests/test-diy-noop.m4 > ../tests/regressiontests/test-diy.m4
argbash ../tests/regressiontests/test-diy.m4 -o ../tests/regressiontests/test-diy.sh
../tests/regressiontests/test-diy.sh LOO | grep -q 'POS_S=LOO',
../tests/regressiontests/test-diy.sh "LOO BAR" | grep -q 'POS_S=LOO BAR,'
../tests/regressiontests/test-diy.sh -b LOO | grep -q BOOL=on,
../tests/regressiontests/test-diy.sh LOO | grep -q BOOL=off,
../tests/regressiontests/test-diy.sh LOO | grep -q 'OPT_S=opt_arg_default lolo',
../tests/regressiontests/test-diy.sh LOO UFTA | grep -q 'POS_OPT=UFTA,'
../tests/regressiontests/test-diy.sh LOO | grep -q 'OPT_INCR=2,'
../tests/regressiontests/test-diy.sh -ii LOO | grep -q 'OPT_INCR=4,'
../tests/regressiontests/test-diy.sh -h | grep -- pos_arg | grep -q pos_arg_help
../tests/regressiontests/test-diy.sh -h | grep -- pos-opt | grep -q @pos-opt-arg@
../tests/regressiontests/test-diy.sh -h | grep -q ' \[<pos-opt>\]'
../tests/regressiontests/test-diy.sh LOO --opt_arg "PoS sob" | grep -q 'OPT_S=PoS sob,'
../tests/regressiontests/test-diy.sh --opt_arg PoS LOO | grep -q OPT_S=PoS,
../tests/regressiontests/test-diy.sh --opt_arg="PoS sob" LOO | grep -q 'OPT_S=PoS sob,'
../tests/regressiontests/test-diy.sh LOO -b | grep -q BOOL=on,
../tests/regressiontests/test-diy.sh LOO --boo_l | grep -q BOOL=on,
../tests/regressiontests/test-diy.sh LOO --boo_l --boo_l | grep -q 'POS_OPT=pos_opt_default lala,'
../tests/regressiontests/test-diy.sh --no-boo_l LOO | grep -q BOOL=off,
../tests/regressiontests/test-diy.sh --opt-incr -i LOO | grep -q 'OPT_INCR=4,'
../tests/regressiontests/test-diy.sh LOO --opt-incr | grep -q 'OPT_INCR=3,'
../tests/regressiontests/reverse ../tests/regressiontests/test-diy.sh LOO --opt_arg 2> /dev/null
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-diy.sh"
argbash ../tests/regressiontests/test-wrapping-single_level.m4 -o ../tests/regressiontests/test-wrapping-single_level.sh
argbash ../tests/regressiontests/test-wrapping-second_level.m4 -o ../tests/regressiontests/test-wrapping-second_level.sh
../tests/regressiontests/test-wrapping-second_level.sh -h | grep -q opt-arg
../tests/regressiontests/test-wrapping-second_level.sh -h | grep -q pos-arg
! ../tests/regressiontests/test-wrapping-second_level.sh -h | grep -q boo_l
! grep -q '^  ' ../tests/regressiontests/test-wrapping-second_level.sh
grep -q '^              esac' ../tests/regressiontests/test-wrapping-second_level.sh
../tests/regressiontests/test-wrapping-second_level.sh XX LOOL | grep -q 'POS_S0=XX,POS_S=LOOL,POS_OPT=pos-default'
../tests/regressiontests/test-wrapping-second_level.sh XX LOOL | grep -q 'POS_S=LOOL,POS_OPT=pos-default'
../tests/regressiontests/test-wrapping-second_level.sh XX LOOL --opt-arg lalala | grep -q OPT_S=lalala,
../tests/regressiontests/test-wrapping-second_level.sh XX LOOL --opt-arg lalala | grep -q 'CMDLINE=--opt-arg lalala XX LOOL pos-default,'
../tests/regressiontests/test-wrapping-second_level.sh XX LOOL --opt-repeated w -r x --opt-repeated=y -rz | grep -q 'CMDLINE=--opt-repeated w -r x --opt-repeated=y -rz XX LOOL pos-default,'
../tests/regressiontests/test-wrapping-second_level.sh XX LOOL | grep -q 'POS_S1=,'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-wrapping-second_level.sh"
argbash ../tests/regressiontests/test-wrapping.m4 -o ../tests/regressiontests/test-wrapping.sh
../tests/regressiontests/test-wrapping.sh -h | grep -q opt-arg
../tests/regressiontests/test-wrapping.sh -h | grep -q pos-arg
! ../tests/regressiontests/test-wrapping.sh -h | grep -q boo_l
! grep -q '^  ' ../tests/regressiontests/test-wrapping.sh
grep -q '^              esac' ../tests/regressiontests/test-wrapping.sh
../tests/regressiontests/test-wrapping.sh XX LOOL | grep -q 'POS_S0=XX,POS_S=LOOL,POS_OPT=pos-default'
../tests/regressiontests/test-wrapping.sh XX LOOL | grep -q 'POS_S=LOOL,POS_OPT=pos-default'
../tests/regressiontests/test-wrapping.sh XX LOOL --opt-arg lalala | grep -q OPT_S=lalala,
../tests/regressiontests/test-wrapping.sh XX LOOL --opt-arg lalala | grep -q 'CMDLINE=--opt-arg lalala LOOL pos-default,'
../tests/regressiontests/test-wrapping.sh XX LOOL --opt-repeated w -r x --opt-repeated=y -rz | grep -q 'CMDLINE=--opt-repeated w -r x --opt-repeated=y -rz LOOL pos-default,'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-wrapping.sh"
mkdir -p ../tests/regressiontests/otherdir && cp ../tests/regressiontests/test-onlyopt.m4 ../tests/regressiontests/otherdir/test-onlyopt.m4
mkdir -p ../tests/regressiontests/otherdir && cp ../tests/regressiontests/test-onlypos.m4 ../tests/regressiontests/otherdir/test-onlypos.m4
argbash ../tests/regressiontests/test-wrapping-otherdir.m4 -o ../tests/regressiontests/test-wrapping-otherdir.sh
../tests/regressiontests/test-wrapping-otherdir.sh -h | grep -q opt-arg
../tests/regressiontests/test-wrapping-otherdir.sh -h | grep -q pos-arg
! ../tests/regressiontests/test-wrapping-otherdir.sh -h | grep -q boo_l
! grep -q '^  ' ../tests/regressiontests/test-wrapping-otherdir.sh
grep -q '^              esac' ../tests/regressiontests/test-wrapping-otherdir.sh
../tests/regressiontests/test-wrapping-otherdir.sh XX LOOL | grep -q 'POS_S0=XX,POS_S=LOOL,POS_OPT=pos-default'
../tests/regressiontests/test-wrapping-otherdir.sh XX LOOL | grep -q 'POS_S=LOOL,POS_OPT=pos-default'
../tests/regressiontests/test-wrapping-otherdir.sh XX LOOL --opt-arg lalala | grep -q OPT_S=lalala,
../tests/regressiontests/test-wrapping-otherdir.sh XX LOOL --opt-arg lalala | grep -q 'CMDLINE=--opt-arg lalala LOOL pos-default,'
../tests/regressiontests/test-wrapping-otherdir.sh XX LOOL --opt-repeated w -r x --opt-repeated=y -rz | grep -q 'CMDLINE=--opt-repeated w -r x --opt-repeated=y -rz LOOL pos-default,'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-wrapping-otherdir.sh"
argbash ../tests/regressiontests/test-wrapping-more.m4 -o ../tests/regressiontests/test-wrapping-more.sh
../tests/regressiontests/test-wrapping-more.sh -i -i -i | grep -q 'CMDLINE=-i -i -i,'
../tests/regressiontests/test-wrapping-more.sh -i -i | grep -q 'OPT_INCR=4,'
ERROR="nexpected argument '--opt-arg'" ../tests/regressiontests/reverse ../tests/regressiontests/test-wrapping-more.sh --opt-arg lalala
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-wrapping-more.sh"
argbash ../tests/regressiontests/test-wrapping-excl.m4 -o ../tests/regressiontests/test-wrapping-excl.sh
../tests/regressiontests/reverse grep -q case ../tests/regressiontests/test-wrapping-excl.sh
../tests/regressiontests/test-wrapping-excl.sh LOO | grep -q POS_S=LOO,POS_OPT=pos-default,
../tests/regressiontests/test-wrapping-excl.sh LOO ar,guma | grep -q POS_S=LOO,POS_OPT=ar,guma,
ERROR=spurious ../tests/regressiontests/reverse ../tests/regressiontests/test-wrapping-excl.sh one two three
ERROR='between 1 and 2' ../tests/regressiontests/reverse ../tests/regressiontests/test-wrapping-excl.sh one two three
ERROR='Not enough' ../tests/regressiontests/reverse ../tests/regressiontests/test-wrapping-excl.sh
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-wrapping-excl.sh"
argbash ../tests/regressiontests/test-wrapping.sh -o ../tests/regressiontests/test-wrapping2.sh
diff -q ../tests/regressiontests/test-wrapping.sh ../tests/regressiontests/test-wrapping2.sh
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-wrapping.sh"
argbash ../tests/regressiontests/test-infinity-minimal_call.m4 -o ../tests/regressiontests/test-infinity-minimal_call.sh
../tests/regressiontests/test-infinity-minimal_call.sh | grep -q 'POS_S='
../tests/regressiontests/test-infinity-minimal_call.sh 1 | grep -q 'POS_S=1,'
../tests/regressiontests/test-infinity-minimal_call.sh 1 2 "3 1 4" 4 5 | grep -q 'POS_S=1,2,3 1 4,4,5,'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-infinity-minimal_call.sh"
argbash ../tests/regressiontests/test-progs.m4 -o ../tests/regressiontests/test-progs.sh
../tests/regressiontests/test-progs.sh -h | grep MAKE | grep -q utility
../tests/regressiontests/test-progs.sh -h | grep FULALA | grep -q BOOM
ERROR="fulala doesnt exist" ../tests/regressiontests/reverse ../tests/regressiontests/test-progs.sh
../tests/regressiontests/test-progs.sh 2>&1 | grep fulala | grep -q exist
FULALA=make ../tests/regressiontests/test-progs.sh
ERROR="make doesnt work" MAKE=false FULALA=make ../tests/regressiontests/reverse ../tests/regressiontests/test-progs.sh
../tests/regressiontests/test-progs.sh -h | grep fulala | grep -q FULALA
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-progs.sh"
argbash ../tests/regressiontests/test-prog.m4 -o ../tests/regressiontests/test-prog.sh
../tests/regressiontests/test-prog.sh -h | grep FULALA | grep -q BOOM
ERROR="fulala doesnt exist" ../tests/regressiontests/reverse ../tests/regressiontests/test-prog.sh
../tests/regressiontests/test-prog.sh 2>&1 | grep fulala | grep -q exist
FULALA=make ../tests/regressiontests/test-prog.sh
../tests/regressiontests/test-prog.sh -h | grep fulala | grep -q FULALA
ERROR="fulala doesnt work" FULALA=false ../tests/regressiontests/reverse ../tests/regressiontests/test-prog.sh
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-prog.sh"
argbash ../tests/regressiontests/test-infinity.m4 -o ../tests/regressiontests/test-infinity.sh
../tests/regressiontests/test-infinity.sh | grep -q 'POS_S=first,second,third,'
../tests/regressiontests/test-infinity.sh 1 | grep -q 'POS_S=1,second,third,'
../tests/regressiontests/test-infinity.sh 1 2 "3 1 4" 4 5 | grep -q 'POS_S=1,2,3 1 4,4,5,'
! grep -q handle_passed_args_count ../tests/regressiontests/test-infinity.sh
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-infinity.sh"
argbash ../tests/regressiontests/test-infinity-nodefaults.m4 -o ../tests/regressiontests/test-infinity-nodefaults.sh
ERROR="require at least 2" ../tests/regressiontests/reverse ../tests/regressiontests/test-infinity-nodefaults.sh
ERROR="namely: 'pos-arg' (2 times)" ../tests/regressiontests/reverse ../tests/regressiontests/test-infinity-nodefaults.sh
../tests/regressiontests/test-infinity-nodefaults.sh 1 "2 3" | grep -q 'POS_S=1,2 3'
../tests/regressiontests/test-infinity-nodefaults.sh 1 2 "3 1 4" 4 5 | grep -q 'POS_S=1,2,3 1 4,4,5,'
grep -q handle_passed_args_count ../tests/regressiontests/test-infinity-nodefaults.sh
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-infinity-nodefaults.sh"
argbash ../tests/regressiontests/test-infinity-mixed.m4 -o ../tests/regressiontests/test-infinity-mixed.sh
../tests/regressiontests/test-infinity-mixed.sh -h | grep -q '<pos-arg-1> \[<pos-arg-2>\] \.\.\. \[<pos-arg-n>\] \.\.\.$'
ERROR="require at least 1" ../tests/regressiontests/reverse ../tests/regressiontests/test-infinity-mixed.sh
../tests/regressiontests/test-infinity-mixed.sh 1 | grep -q 'POS_S=1,first,second'
../tests/regressiontests/test-infinity-mixed.sh 1 2 "3 1 4" 4 5 | grep -q 'POS_S=1,2,3 1 4,4,5,'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-infinity-mixed.sh"
argbash ../tests/regressiontests/test-leftovers.m4 -o ../tests/regressiontests/test-leftovers.sh
../tests/regressiontests/test-leftovers.sh -? | grep -q '\[-c|--cosi <arg>\] \[--(no-)fear\] \[-m|--more\] \[-?|--hilfe\] <another> \.\.\. $'
../tests/regressiontests/test-leftovers.sh -c ours -m --more --more --no-fear "ours pos" left "o ver" | grep -q 'MORE=3,OPT_S=ours,FEAR=off,POS_S=ours pos,LEFTOVERS=left,o ver,'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-leftovers.sh"
argbash ../tests/regressiontests/test-delim-space.m4 -o ../tests/regressiontests/test-delim-space.sh
ERROR="unexpected argument '--opt=something'" ../tests/regressiontests/reverse ../tests/regressiontests/test-delim-space.sh --opt=something
../tests/regressiontests/test-delim-space.sh --opt something | grep -q 'OPT_S=something,'
ERROR="unexpected argument '--add=three'" ../tests/regressiontests/reverse ../tests/regressiontests/test-delim-space.sh -a one --add two --add=three
../tests/regressiontests/test-delim-space.sh -a one --add two | grep -q 'OPT_REP=one two,'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-delim-space.sh"
argbash ../tests/regressiontests/test-delim-equals.m4 -o ../tests/regressiontests/test-delim-equals.sh
ERROR="unexpected argument '--opt'" ../tests/regressiontests/reverse ../tests/regressiontests/test-delim-equals.sh --opt something
../tests/regressiontests/test-delim-equals.sh --opt=something | grep -q 'OPT_S=something,'
../tests/regressiontests/test-delim-equals.sh --xxx | grep -q 'XXX=on,'
ERROR="unexpected argument '--add'" ../tests/regressiontests/reverse ../tests/regressiontests/test-delim-equals.sh -a one --add two --add=three
../tests/regressiontests/test-delim-equals.sh -a one --add=two | grep -q 'OPT_REP=one two,'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-delim-equals.sh"
argbash ../tests/regressiontests/test-delim-both.m4 -o ../tests/regressiontests/test-delim-both.sh
../tests/regressiontests/test-delim-both.sh --opt something | grep -q 'OPT_S=something,'
../tests/regressiontests/test-delim-both.sh --opt=something | grep -q 'OPT_S=something,'
../tests/regressiontests/test-delim-both.sh -a one --add two --add=three | grep -q 'OPT_REP=one two three'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-delim-both.sh"
argbash-init --pos pos --opt opt2 --opt opt --opt-bool boo ../tests/regressiontests/test-init_simple.m4
argbash ../tests/regressiontests/test-init_simple.m4 -o ../tests/regressiontests/test-init_simple.sh
ERROR="[Nn]ot enough" ../tests/regressiontests/reverse ../tests/regressiontests/test-init_simple.sh
../tests/regressiontests/test-init_simple.sh foo | grep -q "'pos': foo"
../tests/regressiontests/test-init_simple.sh foo --opt bar | grep -q " --opt: bar"
../tests/regressiontests/test-init_simple.sh foo --opt bar | grep -q "'boo' is off"
../tests/regressiontests/test-init_simple.sh foo --opt bar --opt2 baz | grep -q " --opt: bar"
../tests/regressiontests/test-init_simple.sh foo --opt bar --opt2 baz | grep -q " --opt2: baz"
../tests/regressiontests/test-init_simple.sh foo --opt bar --opt2 baz --boo | grep -q "'boo' is on"
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-init_simple.sh"
argbash-init --pos pos --opt opt2 --opt opt --opt-bool boo -s ../tests/regressiontests/test-init_simple-s.m4
sed -i '2 s|^|# shellcheck source=../tests/regressiontests/test-init_simple-s-parsing.sh\n|' ../tests/regressiontests/test-init_simple-s.m4
argbash ../tests/regressiontests/test-init_simple-s.m4 -o ../tests/regressiontests/test-init_simple-s.sh
ERROR="[Nn]ot enough" ../tests/regressiontests/reverse ../tests/regressiontests/test-init_simple-s.sh
../tests/regressiontests/test-init_simple-s.sh foo | grep -q "'pos': foo"
../tests/regressiontests/test-init_simple-s.sh foo --opt bar | grep -q " --opt: bar"
../tests/regressiontests/test-init_simple-s.sh foo --opt bar | grep -q "'boo' is off"
../tests/regressiontests/test-init_simple-s.sh foo --opt bar --opt2 baz | grep -q " --opt: bar"
../tests/regressiontests/test-init_simple-s.sh foo --opt bar --opt2 baz | grep -q " --opt2: baz"
../tests/regressiontests/test-init_simple-s.sh foo --opt bar --opt2 baz --boo | grep -q "'boo' is on"
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-init_simple-s.sh"
argbash-init --pos pos --opt opt2 --opt opt --opt-bool boo -s -s ../tests/regressiontests/test-init_simple-ss.sh
sed -i '2 s|^|# shellcheck source=../tests/regressiontests/test-init_simple-ss-parsing.sh\n|' ../tests/regressiontests/test-init_simple-ss.sh
argbash ../tests/regressiontests/test-init_simple-ss-parsing.m4 -o ../tests/regressiontests/test-init_simple-ss-parsing.sh --strip user-content
ERROR="[Nn]ot enough" ../tests/regressiontests/reverse ../tests/regressiontests/test-init_simple-ss.sh
../tests/regressiontests/test-init_simple-ss.sh foo | grep -q "'pos': foo"
../tests/regressiontests/test-init_simple-ss.sh foo --opt bar | grep -q " --opt: bar"
../tests/regressiontests/test-init_simple-ss.sh foo --opt bar | grep -q "'boo' is off"
../tests/regressiontests/test-init_simple-ss.sh foo --opt bar --opt2 baz | grep -q " --opt: bar"
../tests/regressiontests/test-init_simple-ss.sh foo --opt bar --opt2 baz | grep -q " --opt2: baz"
../tests/regressiontests/test-init_simple-ss.sh foo --opt bar --opt2 baz --boo | grep -q "'boo' is on"
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-init_simple-ss.sh"
touch ../tests/regressiontests/regenerate-test-init_simple-s-update.m4
argbash-init --opt ordnung -s ../tests/regressiontests/test-init_simple-s-update.m4 > /dev/null
sed -i '2 s|^|# shellcheck source=../tests/regressiontests/test-init_simple-s-update-parsing.sh\n|' ../tests/regressiontests/test-init_simple-s-update.m4
sed -i 's/^echo .*//' ../tests/regressiontests/test-init_simple-s-update.m4
echo 'test "$_arg_ordnung" = yes || exit 1' >> ../tests/regressiontests/test-init_simple-s-update.m4
argbash ../tests/regressiontests/test-init_simple-s-update.m4 -o ../tests/regressiontests/test-init_simple-s-update.sh
touch ../tests/regressiontests/regenerate-test-init_simple-s-update.m4
../tests/regressiontests/test-init_simple-s-update.sh --ordnung yes > /dev/null
../tests/regressiontests/reverse ../tests/regressiontests/test-init_simple-s-update.sh > /dev/null
ERROR="unexpected argument" ../tests/regressiontests/reverse ../tests/regressiontests/test-init_simple-s-update.sh -o yes > /dev/null
sed -i 's/\[ordnung\]/&,[o]/' ../tests/regressiontests/test-init_simple-s-update-parsing.sh
../tests/regressiontests/../../bin/argbash ../tests/regressiontests/test-init_simple-s-update.sh > /dev/null
../tests/regressiontests/test-init_simple-s-update.sh --ordnung yes > /dev/null
../tests/regressiontests/reverse ../tests/regressiontests/test-init_simple-s-update.sh > /dev/null
../tests/regressiontests/test-init_simple-s-update.sh -o yes > /dev/null
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-init_simple-s-update.sh"
argbash ../tests/regressiontests/test-env-base.m4 -o ../tests/regressiontests/test-env-base.sh
../tests/regressiontests/test-env-base.sh | grep -q 'ENVI_FOO=def,ault,'
../tests/regressiontests/test-env-base.sh | grep -q 'ENVI_BAR=,'
ENVI_FOO=something ../tests/regressiontests/test-env-base.sh | grep -q 'ENVI_FOO=something'
../tests/regressiontests/test-env-base.sh -h | grep -q "ENVI_FOO: A sample env, variable. (default: 'def,ault')"
../tests/regressiontests/test-env-base.sh -h | grep -q "ENVI_BAR: A sample env, variable."
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-env-base.sh"
argbash ../tests/regressiontests/test-env-simple.m4 -o ../tests/regressiontests/test-env-simple.sh
../tests/regressiontests/test-env-simple.sh | grep -q 'ENVI_FOO=def,ault,'
! ../tests/regressiontests/test-env-simple.sh -h | grep -q 'ENVI_FOO'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-env-simple.sh"
argbash ../tests/regressiontests/test-int.m4 -o ../tests/regressiontests/test-int.sh
../tests/regressiontests/test-int.sh 1 | grep -q "POS_S=1,"
ERROR="integer" ../tests/regressiontests/reverse ../tests/regressiontests/test-int.sh a
ERROR="integer" ../tests/regressiontests/reverse ../tests/regressiontests/test-int.sh 1.5
../tests/regressiontests/test-int.sh 1 --int 2 | grep -q "OPT_S=2,"
ERROR="integer" ../tests/regressiontests/reverse ../tests/regressiontests/test-int.sh 1 --int b
../tests/regressiontests/test-int.sh 01 | grep -q "POS_S=1,"
../tests/regressiontests/test-int.sh +1 | grep -q "POS_S=1,"
../tests/regressiontests/test-int.sh -1 | grep -q "POS_S=-1,"
../tests/regressiontests/test-int.sh -1776 | grep -q "POS_S=-1776,"
../tests/regressiontests/test-int.sh -h | grep -q "INT"
../tests/regressiontests/test-int.sh -h | grep -q "INT+0"
../tests/regressiontests/test-int.sh -h | grep -q "INT+"
../tests/regressiontests/test-int.sh 1 --nnint 2 | grep -q "NN=2,"
../tests/regressiontests/test-int.sh 1 --pint 2 | grep -q "P=2,"
ERROR="positive" ../tests/regressiontests/reverse ../tests/regressiontests/test-int.sh 1 --pint 0
ERROR="negative" ../tests/regressiontests/reverse ../tests/regressiontests/test-int.sh 1 --nnint -1
! grep -q $'\t' ../tests/regressiontests/test-int.sh
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-int.sh"
argbash ../tests/regressiontests/test-group.m4 -o ../tests/regressiontests/test-group.sh
../tests/regressiontests/test-group.sh foo | grep -q "ACT=foo"
../tests/regressiontests/test-group.sh '' | grep -q "ACT="
../tests/regressiontests/test-group.sh foo,baz | grep -q "ACT=foo,baz,"
../tests/regressiontests/test-group.sh "bar bar" | grep -q "ACT=bar bar,"
ERROR="allowed" ../tests/regressiontests/reverse ../tests/regressiontests/test-group.sh fuuuu
ERROR="allowed" ../tests/regressiontests/reverse ../tests/regressiontests/test-group.sh bar
! grep -q _idx ../tests/regressiontests/test-group.sh
../tests/regressiontests/test-group.sh -h | grep act-ion | grep -q "'foo,baz'"
../tests/regressiontests/test-group.sh -h | grep act-ion | grep -q "'bar bar'"
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-group.sh"
argbash ../tests/regressiontests/test-group-idx.m4 -o ../tests/regressiontests/test-group-idx.sh
../tests/regressiontests/test-group-idx.sh foo | grep -q "ACT=foo,IDX=0,"
../tests/regressiontests/test-group-idx.sh foo,baz | grep -q "ACT=foo,baz,IDX=3,"
../tests/regressiontests/test-group-idx.sh "bar bar" | grep -q "ACT=bar bar,IDX=2,"
ERROR="allowed" ../tests/regressiontests/reverse ../tests/regressiontests/test-group-idx.sh "bar bar" --repeated bar
! ../tests/regressiontests/test-group-idx.sh "bar bar" --repeated "bar bar" | grep -q "IDX3=2," > /dev/null
../tests/regressiontests/test-group-idx.sh "bar bar" --opt-tion "bar bar" | grep -q "IDX2=2," > /dev/null
ERROR="allowed" ../tests/regressiontests/reverse ../tests/regressiontests/test-group-idx.sh fuuuu
ERROR="allowed" ../tests/regressiontests/reverse ../tests/regressiontests/test-group-idx.sh bar
# ../tests/regressiontests/test-group-idx.sh -h | grep action | grep ACTION | grep -q 'foo,baz'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-group-idx.sh"
printf "%s\n%s\n" "#!/usr/bin/env bash" "set -e" "# ARG_RESTRICT_VALUES([no-local-options])" | cat - ../tests/regressiontests/test-simple.m4 | ../tests/regressiontests/../../bin/argbash -o ../tests/regressiontests/test-semi_strict.sh -
../tests/regressiontests/test-semi_strict.sh -o -x pos-arg | grep -q 'OPT_S=-x,'
../tests/regressiontests/test-semi_strict.sh -o --opt-argx pos-arg | grep -q 'OPT_S=--opt-argx,'
ERROR="omitted the actual value" ../tests/regressiontests/reverse ../tests/regressiontests/test-semi_strict.sh -o -o pos-arg
ERROR="omitted the actual value" ../tests/regressiontests/reverse ../tests/regressiontests/test-semi_strict.sh -o -ofoo pos-arg
ERROR="omitted the actual value" ../tests/regressiontests/reverse ../tests/regressiontests/test-semi_strict.sh -o --prefix
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-semi_strict.sh"
printf "%s\n%s\n" "#!/usr/bin/env bash" "set -e" "# ARG_RESTRICT_VALUES([no-any-options])" | cat - ../tests/regressiontests/test-simple.m4 | ../tests/regressiontests/../../bin/argbash -o ../tests/regressiontests/test-very_strict.sh -
ERROR="are trying to pass an option" ../tests/regressiontests/reverse ../tests/regressiontests/test-very_strict.sh -o -x pos-arg
ERROR="are trying to pass an option" ../tests/regressiontests/reverse ../tests/regressiontests/test-very_strict.sh -o -o pos-arg
ERROR="are trying to pass an option" ../tests/regressiontests/reverse ../tests/regressiontests/test-very_strict.sh -x
ERROR="are trying to pass an option" ../tests/regressiontests/reverse ../tests/regressiontests/test-very_strict.sh --foobar
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-very_strict.sh"
printf "%s\n%s\n%s\n" "#!/usr/bin/env bash" "# ARGBASH_SET_DELIM([ =])" "# ARG_OPTION_STACKING([getopt])" | cat - ../tests/regressiontests/test-onlyopt.m4 | ../tests/regressiontests/../../bin/argbash -o ../tests/regressiontests/test-getopt-both.sh -
../tests/regressiontests/test-getopt-both.sh -ii | grep -q 'OPT_INCR=4,'
../tests/regressiontests/test-getopt-both.sh --incrx -ii | grep -q 'OPT_INCR=5,'
../tests/regressiontests/test-getopt-both.sh -Bi | grep 'OPT_INCR=3,' | grep -q 'BOOL=on,'
../tests/regressiontests/test-getopt-both.sh -Bio bu | grep 'OPT_INCR=3,' | grep 'BOOL=on,' | grep -q 'OPT_S=bu,'
../tests/regressiontests/test-getopt-both.sh -Biobu | grep 'OPT_INCR=3,' | grep 'BOOL=on,' | grep -q 'OPT_S=bu,'
../tests/regressiontests/test-getopt-both.sh -Boibu | grep 'BOOL=on,' | grep 'OPT_INCR=2,' | grep -q 'OPT_S=ibu,'
ERROR="'-Bfoo' can't be decomposed to -B and -foo, because -B doesn't accept value and '-f' doesn't correspond to a short option" ../tests/regressiontests/reverse ../tests/regressiontests/test-getopt-both.sh -Bfoo
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-getopt-both.sh"
printf "%s\n%s\n%s\n" "#!/usr/bin/env bash" "# ARGBASH_SET_DELIM([ ])" "# ARG_OPTION_STACKING([getopt])" | cat - ../tests/regressiontests/test-onlyopt.m4 | ../tests/regressiontests/../../bin/argbash -o ../tests/regressiontests/test-getopt-space.sh -
../tests/regressiontests/test-getopt-space.sh -ii | grep -q 'OPT_INCR=4,'
../tests/regressiontests/test-getopt-space.sh --incrx -ii | grep -q 'OPT_INCR=5,'
../tests/regressiontests/test-getopt-space.sh -Bi | grep 'OPT_INCR=3,' | grep -q 'BOOL=on,'
../tests/regressiontests/test-getopt-space.sh -Bio bu | grep 'OPT_INCR=3,' | grep 'BOOL=on,' | grep -q 'OPT_S=bu,'
../tests/regressiontests/test-getopt-space.sh -Biobu | grep 'OPT_INCR=3,' | grep 'BOOL=on,' | grep -q 'OPT_S=bu,'
../tests/regressiontests/test-getopt-space.sh -Boibu | grep 'BOOL=on,' | grep 'OPT_INCR=2,' | grep -q 'OPT_S=ibu,'
ERROR="'-Bfoo' can't be decomposed to -B and -foo, because -B doesn't accept value and '-f' doesn't correspond to a short option" ../tests/regressiontests/reverse ../tests/regressiontests/test-getopt-space.sh -Bfoo
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-getopt-space.sh"
printf "%s\n%s\n%s\n" "#!/usr/bin/env bash" "# ARGBASH_SET_DELIM([=])" "# ARG_OPTION_STACKING([getopt])" | cat - ../tests/regressiontests/test-onlyopt.m4 | ../tests/regressiontests/../../bin/argbash -o ../tests/regressiontests/test-getopt-equals.sh -
../tests/regressiontests/test-getopt-equals.sh -ii | grep -q 'OPT_INCR=4,'
../tests/regressiontests/test-getopt-equals.sh --incrx -ii | grep -q 'OPT_INCR=5,'
../tests/regressiontests/test-getopt-equals.sh -Bi | grep 'OPT_INCR=3,' | grep -q 'BOOL=on,'
../tests/regressiontests/test-getopt-equals.sh -Bio bu | grep 'OPT_INCR=3,' | grep 'BOOL=on,' | grep -q 'OPT_S=bu,'
../tests/regressiontests/test-getopt-equals.sh -Biobu | grep 'OPT_INCR=3,' | grep 'BOOL=on,' | grep -q 'OPT_S=bu,'
../tests/regressiontests/test-getopt-equals.sh -Boibu | grep 'BOOL=on,' | grep 'OPT_INCR=2,' | grep -q 'OPT_S=ibu,'
ERROR="'-Bfoo' can't be decomposed to -B and -foo, because -B doesn't accept value and '-f' doesn't correspond to a short option" ../tests/regressiontests/reverse ../tests/regressiontests/test-getopt-equals.sh -Bfoo
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-getopt-equals.sh"
../tests/regressiontests/../../bin/argbash ../tests/regressiontests/basic.m4 -t docopt --strip all -o ../tests/regressiontests/basic.txt
grep -q "\[<pos-opt>\]" ../tests/regressiontests/basic.txt
grep -q "\[--opt_arg OPT_ARG\]" ../tests/regressiontests/basic.txt
grep -q "\s-o OPT_ARG, --opt_arg OPT_ARG\s" ../tests/regressiontests/basic.txt
! test -x ../tests/regressiontests/basic.txt
../tests/regressiontests/../../bin/argbash ../tests/regressiontests/test-onlyopt.m4 -t docopt --strip all -o ../tests/regressiontests/test-onlyopt.txt
grep -q "\[--opt-repeated OPT-REPEATED\]\.\.\." ../tests/regressiontests/test-onlyopt.txt
grep -q "\[--incrx\]\.\.\." ../tests/regressiontests/test-onlyopt.txt
argbash ../tests/regressiontests/test-ls_like.m4 -o ../tests/regressiontests/test-ls_like.sh
../tests/regressiontests/../../bin/argbash --type excised -o ../tests/regressiontests/test-ls_like-excised.m4 ../tests/regressiontests/test-ls_like.sh
diff -q ../tests/regressiontests/test-ls_like.m4 ../tests/regressiontests/test-ls_like-excised.m4
../tests/regressiontests/../../bin/argbash --type posix-script -o ../tests/regressiontests/basic-dash.sh ../tests/regressiontests/basic.m4
sed -i "s|#!/usr/bin/env bash|#!/home/yeldir/querbeet/workspace/private/projects/argbash/.devbox/nix/profile/default/bin/dash|" ../tests/regressiontests/basic-dash.sh
../tests/regressiontests/basic-dash.sh LOO | grep -q 'POS_S=LOO',
../tests/regressiontests/basic-dash.sh "LOO BAR" | grep -q 'POS_S=LOO BAR,'
../tests/regressiontests/basic-dash.sh -b LOO | grep -q BOOL=on,
../tests/regressiontests/basic-dash.sh LOO | grep -q BOOL=off,
../tests/regressiontests/basic-dash.sh LOO | grep -q 'OPT_S=opt_arg_default lolo',
../tests/regressiontests/basic-dash.sh LOO UFTA | grep -q 'POS_OPT=UFTA,'
../tests/regressiontests/basic-dash.sh LOO | grep -q 'OPT_INCR=2,'
../tests/regressiontests/basic-dash.sh -ii LOO | grep -q 'OPT_INCR=4,'
../tests/regressiontests/basic-dash.sh -h | grep -- pos_arg | grep -q pos_arg_help
../tests/regressiontests/basic-dash.sh -h | grep -- pos-opt | grep -q @pos-opt-arg@
../tests/regressiontests/basic-dash.sh -h | grep -q ' \[<pos-opt>\]'
! grep -q "local _key$" ../tests/regressiontests/basic-dash.sh
../tests/regressiontests/basic-dash.sh LOO -b | grep -q BOOL=off,
../tests/regressiontests/basic-dash.sh LOO -b | grep -q BOOL=off,
../tests/regressiontests/basic-dash.sh -h | grep -q 'P percent: %'
../tests/regressiontests/basic-dash.sh -h | grep -q 'O percent: %'
../tests/regressiontests/basic-dash.sh -h | grep -qe '\[--\]'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/basic-dash.sh"
../tests/regressiontests/../../bin/argbash --type posix-script -o ../tests/regressiontests/test-onlyopt-dash.sh ../tests/regressiontests/test-onlyopt.m4
sed -i "s|#!/usr/bin/env bash|#!/home/yeldir/querbeet/workspace/private/projects/argbash/.devbox/nix/profile/default/bin/dash|" ../tests/regressiontests/test-onlyopt-dash.sh
grep -q '^    esac$' ../tests/regressiontests/test-onlyopt-dash.sh
! grep -q '^    ' ../tests/regressiontests/test-onlyopt-dash.sh
../tests/regressiontests/reverse grep -q POSITION ../tests/regressiontests/test-onlyopt-dash.sh
../tests/regressiontests/test-onlyopt-dash.sh -o "PoS sob" | grep -q 'OPT_S=PoS sob,'
../tests/regressiontests/test-onlyopt-dash.sh -B | grep -q 'BOOL=on'
../tests/regressiontests/test-onlyopt-dash.sh -i | grep -q 'OPT_INCR=3,'
../tests/regressiontests/test-onlyopt-dash.sh -i -i | grep -q 'OPT_INCR=4,'
! ../tests/regressiontests/test-onlyopt-dash.sh -h | grep -q -e '-B,'
../tests/regressiontests/reverse ../tests/regressiontests/test-onlyopt-dash.sh LOO 2> /dev/null
../tests/regressiontests/test-onlyopt-dash.sh -h | grep -q -e '-B'
../tests/regressiontests/test-onlyopt-dash.sh -h | grep -q -e '-i'
../tests/regressiontests/test-onlyopt-dash.sh -h | grep -q -e '-o <arg>'
../tests/regressiontests/test-onlyopt-dash.sh -h | grep -q -e '-o: @opt-arg@'
! ../tests/regressiontests/test-onlyopt-dash.sh -h | grep -q -e '-r'
ERROR=cosi ../tests/regressiontests/reverse ../tests/regressiontests/test-onlyopt-dash.sh -o lala cosi
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-onlyopt-dash.sh"
../tests/regressiontests/../../bin/argbash --type posix-script -o ../tests/regressiontests/test-simple-dash.sh ../tests/regressiontests/test-simple.m4
sed -i "s|#!/usr/bin/env bash|#!/home/yeldir/querbeet/workspace/private/projects/argbash/.devbox/nix/profile/default/bin/dash|" ../tests/regressiontests/test-simple-dash.sh
../tests/regressiontests/test-simple-dash.sh pos | grep -q 'OPT_S=x,POS_S=pos,'
../tests/regressiontests/test-simple-dash.sh -o 'uf ta' pos | grep -q 'OPT_S=uf ta,POS_S=pos,'
../tests/regressiontests/test-simple-dash.sh -h | grep -q 'END-$'
../tests/regressiontests/test-simple-dash.sh -h | grep -q '^\s*-BEGIN'
../tests/regressiontests/test-simple-dash.sh -h | grep -q '^            -BEGIN'
../tests/regressiontests/test-simple-dash.sh -h | grep -q -v '^\s*-BEGIN2'
../tests/regressiontests/test-simple-dash.sh -h | grep -q -v 'END2-$'
../tests/regressiontests/test-simple-dash.sh -h | grep -q '"line 2" END-\\n'
../tests/regressiontests/test-simple-dash.sh -h | grep -q '^            -PBEGIN'
../tests/regressiontests/test-simple-dash.sh -h | grep -q 'PEND-$'
grep -q '^              esac' ../tests/regressiontests/test-simple-dash.sh
grep -q '^                      \*)' ../tests/regressiontests/test-simple-dash.sh
ERROR=spurious  ../tests/regressiontests/reverse ../tests/regressiontests/test-simple-dash.sh -- one two
ERROR="last one was: 'two'"     ../tests/regressiontests/reverse ../tests/regressiontests/test-simple-dash.sh one two
ERROR="expect exactly 1"        ../tests/regressiontests/reverse ../tests/regressiontests/test-simple-dash.sh one two
ERROR="[Nn]ot enough"   ../tests/regressiontests/reverse ../tests/regressiontests/test-simple-dash.sh
ERROR="require exactly 1"       ../tests/regressiontests/reverse ../tests/regressiontests/test-simple-dash.sh
ERROR="got 3" ../tests/regressiontests/reverse ../tests/regressiontests/test-simple-dash.sh -- -o 'uf ta' pos
ERROR="got 3" ../tests/regressiontests/reverse ../tests/regressiontests/test-simple-dash.sh pos -o 'uf ta'
ERROR="last one was: 'uf ta'" ../tests/regressiontests/reverse ../tests/regressiontests/test-simple-dash.sh pos -o 'uf ta'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 "../tests/regressiontests/test-simple-dash.sh"
ERROR="pos-arg" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-pos.m4 > /dev/null
ERROR="opt-arg" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-opt.m4 > /dev/null
ERROR="pos_arg" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-pos2.m4 > /dev/null
ERROR="opt_arg" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-opt2.m4 > /dev/null
ERROR="number of expected positional arguments before 'pos-arg' is unknown (because of argument 'pos-arg', which has a default)" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-infinity-illegal.m4 > /dev/null
ERROR="'on' or 'off' are allowed as boolean defaults" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-bool-default.m4 > /dev/null
ERROR="same-arg" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-pos-opt.m4 > /dev/null
ERROR="same_arg" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-pos-opt2.m4 > /dev/null
ERROR="ARGBASH_INDICATE_SUPPLIED: The following arguments are not optional: phantom, pos-arg-inf, pos-arg-multi, pos-arg-single, opt-arg-action, opt-arg-incr, opt-arg-repeat" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-supplied-non-optional.m4 > /dev/null
ERROR="is unknown" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-more.m4 > /dev/null
ERROR="contains forbidden characters" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-illegal-pos.m4 > /dev/null
ERROR="one character" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-illegal-opt.m4 > /dev/null
ERROR="ARG_FOOBAR" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-misspelled.m4 > /dev/null
ERROR="ARGBASH_GOO" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-misspelled.m4 > /dev/null
ERROR="unmatched square bracket on line 3" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-unmatched_bracket.m4 > /dev/null
ERROR="# ARG_OPTIONAL_BOOLEAN(\[long\], l, \[)" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-unmatched_bracket.m4 > /dev/null
ERROR="3rd argument" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-badcall-multi.m4 > /dev/null
ERROR="num of args" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-badcall-multi.m4 > /dev/null
ERROR="actual number of" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-badcall-multi.m4 > /dev/null
argbash-init --pos -bool ../tests/regressiontests/gen-test-init_name_dash.m4
ERROR="'-bool' .* begins with a dash" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-init_name_dash.m4 > /dev/null
argbash-init --opt-bool foo/bar-baz ../tests/regressiontests/gen-test-init_name_char.m4
ERROR="'foo/bar-baz' .* contains forbidden characters" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-init_name_char.m4 > /dev/null
sed -e 's/repeated],/foo,&/' ../tests/regressiontests/test-group.m4 > ../tests/regressiontests/gen-test-group-wrong.m4
ERROR="'foo' is not a script argument" ../tests/regressiontests/reverse argbash ../tests/regressiontests/gen-test-group-wrong.m4 > /dev/null
ERROR="supported" ../tests/regressiontests/reverse argbash --type posix-script ../tests/regressiontests/gen-test-infinity.m4 > /dev/null
ERROR="infinite" ../tests/regressiontests/reverse argbash --type posix-script ../tests/regressiontests/gen-test-infinity.m4 > /dev/null
ERROR="supported" ../tests/regressiontests/reverse argbash --type posix-script ../tests/regressiontests/gen-test-wrap.m4 > /dev/null
rm ../tests/regressiontests/test-ls_like.sh
make[1]: Leaving directory '/home/yeldir/querbeet/workspace/private/projects/argbash/resources'
make tests-clean
make[1]: Entering directory '/home/yeldir/querbeet/workspace/private/projects/argbash/resources'
rm -f ../tests/regressiontests/basic2.sh ../tests/regressiontests/test-salone.sh ../tests/regressiontests/test-standalone2.sh ../tests/regressiontests/test-ddash.m4 ../tests/regressiontests/test-diy-noop.m4 ../tests/regressiontests/test-diy-noop.sh ../tests/regressiontests/test-diy.m4 ../tests/regressiontests/test-wrapping-second_level.sh ../tests/regressiontests/test-wrapping-single_level.sh ../tests/regressiontests/otherdir/test-onlyopt.m4 ../tests/regressiontests/test-wrapping-otherdir.sh ../tests/regressiontests/otherdir/test-onlypos.m4 ../tests/regressiontests/test-wrapping2.sh ../tests/regressiontests/test-init_simple.sh ../tests/regressiontests/test-init_simple.m4 ../tests/regressiontests/test-init_simple-parsing.m4 ../tests/regressiontests/test-init_simple-s.sh ../tests/regressiontests/test-init_simple-s-parsing.sh ../tests/regressiontests/test-init_simple-s-parsing.m4 ../tests/regressiontests/test-init_simple-s.m4 ../tests/regressiontests/regenerate-test-init-simple-s-update.m4 ../tests/regressiontests/test-init_simple-s-update-parsing.sh ../tests/regressiontests/test-init_simple-s-update-parsing.m4 ../tests/regressiontests/regenerate-test-init_simple-s-update.m4 ../tests/regressiontests/test-init_simple-s-update.m4 ../tests/regressiontests/test-init_simple-ss-parsing.sh ../tests/regressiontests/test-init_simple-ss-parsing.m4 ../tests/regressiontests/test-init_simple-ss.sh ../tests/regressiontests/gen-test-init_name_char.m4 ../tests/regressiontests/gen-test-init_name_dash.m4 ../tests/regressiontests/gen-test-group-wrong.m4 ../tests/regressiontests/test-semi_strict.sh ../tests/regressiontests/test-very_strict.sh ../tests/regressiontests/test-getopt-equals.sh ../tests/regressiontests/test-getopt-both.sh ../tests/regressiontests/test-getopt-space.sh  ../tests/regressiontests/basic.sh ../tests/regressiontests/test-void.sh ../tests/regressiontests/call-salone.sh ../tests/regressiontests/test-most.sh ../tests/regressiontests/test-more.sh ../tests/regressiontests/test-onlypos.sh ../tests/regressiontests/test-onlypos-declared.sh ../tests/regressiontests/test-onlyopt.sh ../tests/regressiontests/test-standalone.sh ../tests/regressiontests/test-ddash.sh ../tests/regressiontests/test-simple.sh ../tests/regressiontests/test-diy-noop.sh ../tests/regressiontests/test-diy.sh ../tests/regressiontests/test-wrapping-second_level.sh ../tests/regressiontests/test-wrapping.sh ../tests/regressiontests/test-wrapping-otherdir.sh ../tests/regressiontests/test-wrapping-more.sh ../tests/regressiontests/test-wrapping-excl.sh ../tests/regressiontests/test-infinity-minimal_call.sh ../tests/regressiontests/test-progs.sh ../tests/regressiontests/test-prog.sh ../tests/regressiontests/test-infinity.sh ../tests/regressiontests/test-infinity-nodefaults.sh ../tests/regressiontests/test-infinity-mixed.sh ../tests/regressiontests/test-leftovers.sh ../tests/regressiontests/test-delim-space.sh ../tests/regressiontests/test-delim-equals.sh ../tests/regressiontests/test-delim-both.sh ../tests/regressiontests/test-init_simple.sh ../tests/regressiontests/test-init_simple-s.sh ../tests/regressiontests/test-init_simple-ss.sh ../tests/regressiontests/test-init_simple-s-update.sh ../tests/regressiontests/test-env-base.sh ../tests/regressiontests/test-env-simple.sh ../tests/regressiontests/test-int.sh ../tests/regressiontests/test-group.sh ../tests/regressiontests/test-group-idx.sh ../tests/regressiontests/test-semi_strict.sh ../tests/regressiontests/test-very_strict.sh ../tests/regressiontests/test-getopt-both.sh ../tests/regressiontests/test-getopt-space.sh ../tests/regressiontests/test-getopt-equals.sh ../tests/regressiontests/basic.txt ../tests/regressiontests/test-onlyopt.txt ../tests/regressiontests/test-ls_like-excised.m4  ../tests/regressiontests/basic-dash.sh ../tests/regressiontests/test-onlyopt-dash.sh ../tests/regressiontests/test-simple-dash.sh
rmdir ../tests/regressiontests/otherdir
make[1]: Leaving directory '/home/yeldir/querbeet/workspace/private/projects/argbash/resources'
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 ../tests/regressiontests/../../bin/argbash
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 ../tests/regressiontests/../../bin/argbash-init
test -z "shellcheck -x -e 2015" || shellcheck -x -e 2015 ../bin/argbash-1to2
*** All is OK ***
```
</p>
</details> 