### PR TITLE
Fix uninitialized wrapped script arrays causing shellcheck failures

### DIFF
--- a/src/function_generators.m4
+++ b/src/function_generators.m4
@@ -154,6 +154,8 @@ m4_define([_MAKE_ASSIGN_POSITIONAL_ARGS_FUNCTION], [MAKE_FUNCTION(
 	)],
 	[m4_list_ifempty([_WRAPPED_ADD_SINGLE], [], [m4_do(
 		[m4_set_foreach([_POS_VARNAMES], [varname], [m4_n([_INDENT_()varname=()])])],
+		[_INDENT_()# shellcheck disable=SC2154  # the _arg_* variables are assigned via eval
+],
 		[_INDENT_()m4_list_join([_WRAPPED_ADD_SINGLE], m4_newline([_INDENT_()]))],
 		[
 ],

--- a/src/stuff.m4
+++ b/src/stuff.m4
@@ -1225,6 +1225,9 @@ m4_define([_MAKE_DEFAULTS_POSITIONAL], [m4_do(
 	[[_positionals=()]_ENDL_],
 	[m4_lists_foreach_positional([_ARGS_LONG,_POSITIONALS_MINS,_POSITIONALS_DEFAULTS,_ARGS_CATH], [_argname,_min_argn,_defaults,_arg_type],
 		[_MAKE_DEFAULTS_POSITIONALS_LOOP(_argname, _arg_type, _min_argn, _defaults)])],
+	[dnl Initialize wrapped argument arrays (both _opt and _pos) for all groups to ensure they exist
+],
+	[m4_set_foreach([_ARGS_GROUPS], [agroup], [agroup[]_opt_suffix=()_ENDL_[]agroup[]_pos_suffix=()_ENDL_])],
 )])
 
 
@@ -1250,6 +1253,9 @@ m4_define([_MAKE_DEFAULTS_OPTIONAL], [m4_do(
 			[_arg_varname=_sh_quote(_default)_ENDL_])],
 		[m4_set_contains([HAVE_SUPPLIED], _argname, [[_supplied]_arg_varname=0]_ENDL_, [])],
 	)])],
+	[dnl Initialize wrapped argument arrays (both _opt and _pos) for all groups to ensure they exist
+],
+	[m4_set_foreach([_ARGS_GROUPS], [agroup], [agroup[]_opt_suffix=()_ENDL_[]agroup[]_pos_suffix=()_ENDL_])],
 )])
 
 


### PR DESCRIPTION
## Fix uninitialized wrapped script arrays causing shellcheck failures

When ARGBASH_WRAP is used, the code generator creates combined arrays
that reference both _opt and _pos suffixed arrays for each wrapped
script group:

    _args_test_onlyopt=("${_args_test_onlyopt_opt[@]}" "${_args_test_onlyopt_pos[@]}")

However, if a wrapped script only had positional arguments OR only
optional arguments, one of these arrays would never be initialized,
causing shellcheck SC2154 warnings ('variable referenced but not
assigned') and test failures.

This commit fixes the issue by:

1. Initializing both _opt and _pos arrays as empty arrays for ALL
   wrapped script groups during the defaults initialization phase.
   This is done in both _MAKE_DEFAULTS_POSITIONAL and
   _MAKE_DEFAULTS_OPTIONAL to ensure coverage regardless of which
   argument types the script has.

2. Adding a shellcheck disable directive (SC2154) in the generated
   assign_positional_args function where wrapped positional arrays
   reference variables like $_arg_pos_arg. These variables ARE
   assigned via eval, but shellcheck cannot trace dynamic assignments:

       eval "$_positional_name=\${1}"

   The disable directive prevents false positive warnings while
   keeping shellcheck validation for the rest of the generated code.

Fixes shellcheck errors in scripts using ARGBASH_WRAP such as:
- test-wrapping-second_level.sh
- test-wrapping-excl.sh

Assisted-by: Claude 4.5 Opus
Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>
